### PR TITLE
fix AggregateComplete tx cosign, update npm dependencies

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,6 +35,18 @@
                 "minRemoval": 2
             },
             {
+                "alias": "multilevelmultisig",
+                "pk": "3796512b550846d427bde34e6071636322ebd664c0b54532751d60087b8ff781",
+                "seed": 1000,
+                "cosignatories": [
+                    "multisig",
+                    "cosignatory4",
+                    "cosignatory5"
+                ],
+                "minApproval": 2,
+                "minRemoval": 2
+            },
+            {
                 "alias": "cosignatory1",
                 "pk": "7ad5e23f2e71e7a470deaa0f4f85c414ff915d8a670a598c6600c461b72e9f18",
                 "seed": 1000
@@ -47,6 +59,16 @@
             {
                 "alias": "cosignatory3",
                 "pk": "4b10401ddbd46c835b852b9d17433ab453499b239b9ee07d4406da48f0e3cf07",
+                "seed": 100
+            },
+            {
+                "alias": "cosignatory4",
+                "pk": "4b10401ddbd46c835b852b9d17433ab453499b239b9ee07d4406da48f0e3cf08",
+                "seed": 100
+            },
+            {
+                "alias": "cosignatory5",
+                "pk": "4b10401ddbd46c835b852b9d17433ab453499b239b9ee07d4406da48f0e3cf09",
                 "seed": 100
             },
             {

--- a/e2e/conf/conf.spec.ts
+++ b/e2e/conf/conf.spec.ts
@@ -56,6 +56,9 @@ interface ConfEnv {
     TEST_TEST_ACCOUNT9_KEY: string;
     TEST_TEST_ACCOUNT10_KEY: string;
     TEST_TEST_ACCOUNT11_KEY: string;
+    TEST_TEST_ACCOUNT12_KEY: string;
+    TEST_TEST_ACCOUNT13_KEY: string;
+    TEST_TEST_ACCOUNT14_KEY: string;
 }
 
 const api = conf.get('api') as ConfApi;
@@ -101,11 +104,14 @@ const loadEnvKeys = () => {
         ["cosignatory1", systemEnv.TEST_TEST_ACCOUNT4_KEY],
         ["cosignatory2", systemEnv.TEST_TEST_ACCOUNT5_KEY],
         ["cosignatory3", systemEnv.TEST_TEST_ACCOUNT6_KEY],
+        ["cosignatory4", systemEnv.TEST_TEST_ACCOUNT13_KEY],
+        ["cosignatory5", systemEnv.TEST_TEST_ACCOUNT14_KEY],
         ["customer1", systemEnv.TEST_TEST_ACCOUNT7_KEY],
         ["executor1", systemEnv.TEST_TEST_ACCOUNT8_KEY],
         ["executor2", systemEnv.TEST_TEST_ACCOUNT9_KEY],
         ["verifier1", systemEnv.TEST_TEST_ACCOUNT10_KEY],
         ["verifier2", systemEnv.TEST_TEST_ACCOUNT11_KEY],
+        ["multilevelmultisig", systemEnv.TEST_TEST_ACCOUNT12_KEY],
     ])
 }
 const loadBlockchainConfAccouns = (conf: ConfBlockchain) => {
@@ -146,11 +152,14 @@ const MultisigAccount = (accounts.get("multisig") as unknown as TestAccount).acc
 const CosignatoryAccount = (accounts.get("cosignatory1") as unknown as TestAccount).acc;
 const Cosignatory2Account = (accounts.get("cosignatory2") as unknown as TestAccount).acc;
 const Cosignatory3Account = (accounts.get("cosignatory3") as unknown as TestAccount).acc;
+const Cosignatory4Account = (accounts.get("cosignatory4") as unknown as TestAccount).acc;
+const Cosignatory5Account = (accounts.get("cosignatory5") as unknown as TestAccount).acc;
 const Customer1Account = (accounts.get("customer1") as unknown as TestAccount).acc;
 const Executor1Account = (accounts.get("executor1") as unknown as TestAccount).acc;
 const Executor2Account = (accounts.get("executor2") as unknown as TestAccount).acc;
 const Verifier1Account = (accounts.get("verifier1") as unknown as TestAccount).acc;
 const Verifier2Account = (accounts.get("verifier2") as unknown as TestAccount).acc;
+const MultilevelMultisigAccount = (accounts.get("multilevelmultisig") as unknown as TestAccount).acc;
 
 const AllTestingAccounts = accounts;
 
@@ -242,11 +251,14 @@ export {
     CosignatoryAccount,
     Cosignatory2Account,
     Cosignatory3Account,
+    Cosignatory4Account,
+    Cosignatory5Account,
     Customer1Account,
     Executor1Account,
     Executor2Account,
     Verifier1Account,
     Verifier2Account,
+    MultilevelMultisigAccount,
 
     AllTestingAccounts,
 

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -13,26 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {assert, expect} from 'chai';
+import { assert, expect } from 'chai';
 import * as CryptoJS from 'crypto-js';
-import {ChronoUnit} from 'js-joda';
-import {keccak_256, sha3_256} from 'js-sha3';
-import {Crypto} from '../../src/core/crypto';
+import { ChronoUnit } from 'js-joda';
+import { keccak_256, sha3_256 } from 'js-sha3';
+import { Crypto } from '../../src/core/crypto';
 import { Convert as convert } from '../../src/core/format';
-import {AccountHttp} from '../../src/infrastructure/AccountHttp';
+import { AccountHttp } from '../../src/infrastructure/AccountHttp';
 import { NamespaceHttp } from '../../src/infrastructure/infrastructure';
-import {Listener} from '../../src/infrastructure/Listener';
-import {TransactionHttp} from '../../src/infrastructure/TransactionHttp';
-import {Account} from '../../src/model/account/Account';
+import { Listener } from '../../src/infrastructure/Listener';
+import { TransactionHttp } from '../../src/infrastructure/TransactionHttp';
+import { Account } from '../../src/model/account/Account';
 import { RestrictionModificationType } from '../../src/model/account/RestrictionModificationType';
 import { RestrictionType } from '../../src/model/account/RestrictionType';
-import {NetworkType} from '../../src/model/blockchain/NetworkType';
+import { NetworkType } from '../../src/model/blockchain/NetworkType';
 import { Mosaic } from '../../src/model/mosaic/Mosaic';
-import {MosaicId} from '../../src/model/mosaic/MosaicId';
-import {MosaicNonce} from '../../src/model/mosaic/MosaicNonce';
-import {MosaicProperties} from '../../src/model/mosaic/MosaicProperties';
-import {MosaicSupplyType} from '../../src/model/mosaic/MosaicSupplyType';
-import {NetworkCurrencyMosaic} from '../../src/model/mosaic/NetworkCurrencyMosaic';
+import { MosaicId } from '../../src/model/mosaic/MosaicId';
+import { MosaicNonce } from '../../src/model/mosaic/MosaicNonce';
+import { MosaicProperties } from '../../src/model/mosaic/MosaicProperties';
+import { MosaicSupplyType } from '../../src/model/mosaic/MosaicSupplyType';
+import { NetworkCurrencyMosaic } from '../../src/model/mosaic/NetworkCurrencyMosaic';
 import { AliasActionType } from '../../src/model/namespace/AliasActionType';
 import { NamespaceId } from '../../src/model/namespace/NamespaceId';
 import { AccountAddressRestrictionModificationTransaction } from '../../src/model/transaction/AccountAddressRestrictionModificationTransaction';
@@ -42,26 +42,28 @@ import { AccountOperationRestrictionModificationTransaction } from '../../src/mo
 import { AccountRestrictionModification } from '../../src/model/transaction/AccountRestrictionModification';
 import { AccountRestrictionTransaction } from '../../src/model/transaction/AccountRestrictionTransaction';
 import { AddressAliasTransaction } from '../../src/model/transaction/AddressAliasTransaction';
-import {AggregateTransaction} from '../../src/model/transaction/AggregateTransaction';
-import {CosignatureSignedTransaction} from '../../src/model/transaction/CosignatureSignedTransaction';
-import {Deadline} from '../../src/model/transaction/Deadline';
+import { AggregateTransaction } from '../../src/model/transaction/AggregateTransaction';
+import { CosignatureSignedTransaction } from '../../src/model/transaction/CosignatureSignedTransaction';
+import { Deadline } from '../../src/model/transaction/Deadline';
 import { HashLockTransaction } from '../../src/model/transaction/HashLockTransaction';
-import {HashType} from '../../src/model/transaction/HashType';
+import { HashType } from '../../src/model/transaction/HashType';
 import { LinkAction } from '../../src/model/transaction/LinkAction';
-import {LockFundsTransaction} from '../../src/model/transaction/LockFundsTransaction';
+import { LockFundsTransaction } from '../../src/model/transaction/LockFundsTransaction';
 import { MosaicAliasTransaction } from '../../src/model/transaction/MosaicAliasTransaction';
-import {MosaicDefinitionTransaction} from '../../src/model/transaction/MosaicDefinitionTransaction';
-import {MosaicSupplyChangeTransaction} from '../../src/model/transaction/MosaicSupplyChangeTransaction';
+import { MosaicDefinitionTransaction } from '../../src/model/transaction/MosaicDefinitionTransaction';
+import { MosaicSupplyChangeTransaction } from '../../src/model/transaction/MosaicSupplyChangeTransaction';
 import { PlainMessage, EmptyMessage } from '../../src/model/transaction/PlainMessage';
-import {RegisterNamespaceTransaction} from '../../src/model/transaction/RegisterNamespaceTransaction';
-import {SecretLockTransaction} from '../../src/model/transaction/SecretLockTransaction';
-import {SecretProofTransaction} from '../../src/model/transaction/SecretProofTransaction';
-import {Transaction} from '../../src/model/transaction/Transaction';
-import {TransactionType} from '../../src/model/transaction/TransactionType';
-import {TransferTransaction} from '../../src/model/transaction/TransferTransaction';
-import {UInt64} from '../../src/model/UInt64';
-import {APIUrl , ConfNetworkType, ConfNetworkMosaic,
-    SeedAccount, TestingAccount, TestingRecipient, MultisigAccount, CosignatoryAccount, Cosignatory2Account, Cosignatory3Account, GetNemesisBlockDataPromise, ConfNamespace, ConfTestingMosaic, ConfTestingNamespace, ConfAccountHttp, ConfTransactionHttp, ConfMosaicHttp, NemesisBlockInfo, Customer1Account} from '../conf/conf.spec';
+import { RegisterNamespaceTransaction } from '../../src/model/transaction/RegisterNamespaceTransaction';
+import { SecretLockTransaction } from '../../src/model/transaction/SecretLockTransaction';
+import { SecretProofTransaction } from '../../src/model/transaction/SecretProofTransaction';
+import { Transaction } from '../../src/model/transaction/Transaction';
+import { TransactionType } from '../../src/model/transaction/TransactionType';
+import { TransferTransaction } from '../../src/model/transaction/TransferTransaction';
+import { UInt64 } from '../../src/model/UInt64';
+import {
+    APIUrl, ConfNetworkType, ConfNetworkMosaic,
+    SeedAccount, TestingAccount, TestingRecipient, MultisigAccount, CosignatoryAccount, Cosignatory2Account, Cosignatory3Account, GetNemesisBlockDataPromise, ConfNamespace, ConfTestingMosaic, ConfTestingNamespace, ConfAccountHttp, ConfTransactionHttp, ConfMosaicHttp, NemesisBlockInfo, Customer1Account, ConfNetworkMosaicDivisibility
+} from '../conf/conf.spec';
 import { AliasTransaction, Address, SignedTransaction } from '../../src/model/model';
 import { ModifyMetadataTransaction, MetadataModification, MetadataModificationType } from '../../src/model/transaction/ModifyMetadataTransaction';
 import { MetadataHttp } from '../../src/infrastructure/MetadataHttp';
@@ -69,6 +71,7 @@ import { ConfUtils } from '../conf/ConfUtils';
 import { MosaicHttp } from '../../src/infrastructure/MosaicHttp';
 import { fail } from 'assert';
 import { randomBytes } from 'crypto';
+import { validateTransactionConfirmed } from '../utils';
 
 describe('TransactionHttp', () => {
     let transactionHttp: TransactionHttp;
@@ -96,54 +99,6 @@ describe('TransactionHttp', () => {
         listener.close();
     })
 
-    const validateTransactionAnnounceCorrectly = (address: Address, done, hash?: string) => {
-        const status = listener.status(address).subscribe(error => {
-            console.error(error);
-            status.unsubscribe();
-            sub.unsubscribe();
-            return fail("Status reported an error.");
-        });
-        const sub = listener.confirmed(address).subscribe((transaction: Transaction) => {
-            if (hash) {
-                if (transaction && transaction.transactionInfo && transaction.transactionInfo.hash === hash) {
-                    // console.log(transaction);
-                    status.unsubscribe();
-                    sub.unsubscribe();
-                    return done();
-                }
-            } else {
-                status.unsubscribe();
-                sub.unsubscribe();
-                return done();
-            }
-        });
-    }
-
-    const validatePartialTransactionAnnounceCorrectly = (address: Address, done) => {
-        const sub = listener.aggregateBondedAdded(address).subscribe((transaction: Transaction) => {
-            sub.unsubscribe();
-            return done();
-        });
-    }
-
-    const validateCosignaturePartialTransactionAnnounceCorrectly = (address: Address, publicKey, done) => {
-        const sub = listener.cosignatureAdded(address).subscribe((signature) => {
-            if (signature.signer === publicKey) {
-                sub.unsubscribe();
-                return done();
-            }
-        });
-    }
-
-    const validatePartialTransactionNotPartialAnyMore = (address: Address, hash: string, done) => {
-        const sub = listener.aggregateBondedRemoved(address).subscribe(txhash => {
-            if (txhash === hash) {
-                sub.unsubscribe();
-                return done();
-            }
-        });
-    }
-
     describe('announce', () => {
         describe('TransferTransaction', () => {
             const transferTransaction = TransferTransaction.create(
@@ -154,7 +109,8 @@ describe('TransactionHttp', () => {
                 ConfNetworkType);
             it('standalone', (done) => {
                 const signedTransaction = transferTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
             it('aggregate', (done) => {
@@ -164,7 +120,9 @@ describe('TransactionHttp', () => {
                     [],
                 );
                 const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
                 transactionHttp.announce(signedTransaction);
             });
         });
@@ -181,7 +139,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                 );
                 const signedTransaction = registerNamespaceTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
             it('aggregate', (done) => {
@@ -196,7 +155,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                     []);
                 const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
         });
@@ -219,18 +179,23 @@ describe('TransactionHttp', () => {
                 );
                 const signedTransaction = mosaicDefinitionTransaction.signWith(TestingAccount, generationHash);
                 console.log(mosaicId.toHex());
-                validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const modifyMetadataTransaction = ModifyMetadataTransaction.createWithMosaicId(
-                            ConfNetworkType,
-                            Deadline.create(),
-                            undefined,
-                            mosaicId,
-                            [new MetadataModification(MetadataModificationType.ADD, "key2", "some other value")]
-                        );
-
-                        const signedTransaction = modifyMetadataTransaction.signWith(TestingAccount, generationHash);
-                        validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                        transactionHttp.announce(signedTransaction);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash).then(() => {
+                    const modifyMetadataTransaction = ModifyMetadataTransaction.createWithMosaicId(
+                        ConfNetworkType,
+                        Deadline.create(),
+                        undefined,
+                        mosaicId,
+                        [new MetadataModification(MetadataModificationType.ADD, "key2", "some other value")]
+                    );
+                    const signedTransaction = modifyMetadataTransaction.signWith(TestingAccount, generationHash);
+                    validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash).then(() => {
+                        done();
+                    }, (error) => {
+                        fail(error);
+                    })
+                    transactionHttp.announce(signedTransaction);
+                }, (error) => {
+                    fail(error);
                 });
                 transactionHttp.announce(signedTransaction);
             });
@@ -255,7 +220,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                     []);
                 const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
         });
@@ -277,7 +243,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                 );
                 const signedTransaction = mosaicDefinitionTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
 
@@ -301,7 +268,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                     []);
                 const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
         });
@@ -316,10 +284,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType
                 );
                 const signedTransaction = addressAliasTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                    done();
-                }, signedTransaction.hash);
-
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
             it('should remove the alias from an account', (done) => {
@@ -331,10 +297,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType
                 );
                 const signedTransaction = addressAliasTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                    done();
-                }, signedTransaction.hash);
-
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
             it('should create an alias to a mosaic', (done) => {
@@ -347,9 +311,9 @@ describe('TransactionHttp', () => {
                 );
                 console.log(mosaicAliasTransaction);
                 const signedTransaction = mosaicAliasTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                    done();
-                }, signedTransaction.hash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
 
                 transactionHttp.announce(signedTransaction);
             });
@@ -362,9 +326,9 @@ describe('TransactionHttp', () => {
                     ConfNetworkType
                 );
                 const signedTransaction = mosaicAliasTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                    done();
-                }, signedTransaction.hash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
 
                 transactionHttp.announce(signedTransaction);
             });
@@ -380,7 +344,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                 );
                 const signedTransaction = mosaicSupplyChangeTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
             it('aggregate', (done) => {
@@ -396,7 +361,8 @@ describe('TransactionHttp', () => {
                     ConfNetworkType,
                     []);
                 const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
         });
@@ -415,7 +381,8 @@ describe('TransactionHttp', () => {
                 ConfNetworkType,
             );
             const signedTransaction = addressModification.signWith(TestingAccount, generationHash);
-            validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
 
@@ -436,10 +403,10 @@ describe('TransactionHttp', () => {
                 [],
             );
             const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-            validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
-
     });
 
     describe('AccountRestrictionTransaction - Mosaic', () => {
@@ -455,7 +422,8 @@ describe('TransactionHttp', () => {
                 ConfNetworkType,
             );
             const signedTransaction = addressModification.signWith(TestingAccount, generationHash);
-            validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
 
@@ -476,7 +444,8 @@ describe('TransactionHttp', () => {
                 [],
             );
             const signedTransaction = aggregateTransaction.signWith(TestingAccount, generationHash);
-            validateTransactionAnnounceCorrectly(TestingAccount.address, done, signedTransaction.hash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
     });
@@ -495,8 +464,8 @@ describe('TransactionHttp', () => {
             );
             const signedTransaction = addressModification.signWith(Cosignatory2Account, generationHash);
 
-            validateTransactionAnnounceCorrectly(Cosignatory2Account.address, done, signedTransaction.hash);
-
+            validateTransactionConfirmed(listener, Cosignatory2Account.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
 
@@ -517,7 +486,8 @@ describe('TransactionHttp', () => {
                 [],
             );
             const signedTransaction = aggregateTransaction.signWith(Cosignatory2Account, generationHash);
-            validateTransactionAnnounceCorrectly(Cosignatory2Account.address, done, signedTransaction.hash);
+            validateTransactionConfirmed(listener, Cosignatory2Account.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
             transactionHttp.announce(signedTransaction);
         });
     });
@@ -563,16 +533,8 @@ describe('TransactionHttp', () => {
             transactionHttp.announce(signedTransaction);
         });
     });
-
+*/
     describe('LockFundsTransaction', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
         it('standalone', (done) => {
             const aggregateTransaction = AggregateTransaction.createBonded(
                 Deadline.create(),
@@ -580,33 +542,18 @@ describe('TransactionHttp', () => {
                 ConfNetworkType,
                 [],
             );
-            const signedTransaction = account.sign(aggregateTransaction, generationHash);
+            const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
             const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-                new Mosaic(networkCurrencyMosaicId, UInt64.fromUint(10 * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY))),
+                new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * Math.pow(10, ConfNetworkMosaicDivisibility))),
                 UInt64.fromUint(10000),
                 signedTransaction,
                 ConfNetworkType);
+            const signedLockFundsTransaction = lockFundsTransaction.signWith(TestingAccount, generationHash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedLockFundsTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
+            transactionHttp.announce(signedLockFundsTransaction);
+        });
 
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(lockFundsTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('LockFundsTransaction', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
         it('aggregate', (done) => {
             const aggregateTransaction = AggregateTransaction.createBonded(
                 Deadline.create(),
@@ -614,621 +561,218 @@ describe('TransactionHttp', () => {
                 ConfNetworkType,
                 [],
             );
-            const signedTransaction = account.sign(aggregateTransaction, generationHash);
+            const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
             const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-                new Mosaic(networkCurrencyMosaicId, UInt64.fromUint(10 * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY))),
+                new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * Math.pow(10, ConfNetworkMosaicDivisibility))),
                 UInt64.fromUint(10),
                 signedTransaction,
                 ConfNetworkType);
             const aggregateLockFundsTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                [lockFundsTransaction.toAggregate(account.publicAccount)],
+                [lockFundsTransaction.toAggregate(TestingAccount.publicAccount)],
                 ConfNetworkType,
                 []);
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(aggregateLockFundsTransaction.signWith(account, generationHash));
+            const signedAggregateLockFundsTransaction = aggregateLockFundsTransaction.signWith(TestingAccount, generationHash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedAggregateLockFundsTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
+            transactionHttp.announce(signedAggregateLockFundsTransaction);
         });
     });
 
     describe('Aggregate Complete Transaction', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
         it('should announce aggregated complete transaction', (done) => {
-            const tx = TransferTransaction.create(
+            const transaction = TransferTransaction.create(
                 Deadline.create(),
-                account2.address,
+                TestingRecipient.address,
                 [],
                 PlainMessage.create('Hi'),
                 ConfNetworkType,
             );
-            const aggTx = AggregateTransaction.createComplete(
+            const aggregateTransaction = AggregateTransaction.createComplete(
                 Deadline.create(),
                 [
-                    tx.toAggregate(account.publicAccount),
+                    transaction.toAggregate(TestingAccount.publicAccount),
                 ],
                 ConfNetworkType,
                 [],
             );
-            const signedTx = account.sign(aggTx, generationHash);
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(signedTx);
+            const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
+            validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                .then(() => done()).catch((reason) => fail(reason));
+            transactionHttp.announce(signedTransaction);
         });
     });
 
     describe('SecretLockTransaction', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('standalone', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Sha3_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
-                account2.address,
-                ConfNetworkType,
-            );
-            listener.confirmed(account.address).subscribe((transaction: SecretLockTransaction) => {
-                expect(transaction.mosaic, 'Mosaic').not.to.be.undefined;
-                expect(transaction.duration, 'Duration').not.to.be.undefined;
-                expect(transaction.hashType, 'HashType').not.to.be.undefined;
-                expect(transaction.secret, 'Secret').not.to.be.undefined;
-                expect(transaction.recipient, 'Recipient').not.to.be.undefined;
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(secretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Op_Sha3_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-
-        it('aggregate', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Sha3_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
-                account2.address,
-                ConfNetworkType,
-            );
-            const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                [secretLockTransaction.toAggregate(account.publicAccount)],
-                ConfNetworkType,
-                []);
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(aggregateSecretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Keccak_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('standalone', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Keccak_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
-                account2.address,
-                ConfNetworkType,
-            );
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(secretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Keccak_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('aggregate', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Keccak_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
-                account2.address,
-                ConfNetworkType,
-            );
-            const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                [secretLockTransaction.toAggregate(account.publicAccount)],
-                ConfNetworkType,
-                []);
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(aggregateSecretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Op_Hash_160', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('standalone', (done) => {
-            const secretSeed = String.fromCharCode.apply(null, Crypto.randomBytes(20));
-            const secret = CryptoJS.RIPEMD160(CryptoJS.SHA256(secretSeed).toString(CryptoJS.enc.Hex)).toString(CryptoJS.enc.Hex);
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Hash_160,
-                secret,
-                account2.address,
-                ConfNetworkType,
-            );
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(secretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Op_Hash_160', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('aggregate', (done) => {
-            const secretSeed = String.fromCharCode.apply(null, Crypto.randomBytes(20));
-            const secret = CryptoJS.RIPEMD160(CryptoJS.SHA256(secretSeed).toString(CryptoJS.enc.Hex)).toString(CryptoJS.enc.Hex);
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Hash_160,
-                secret,
-                account2.address,
-                ConfNetworkType,
-            );
-            const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                [secretLockTransaction.toAggregate(account.publicAccount)],
-                ConfNetworkType,
-                []);
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(aggregateSecretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Op_Hash_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('standalone', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Hash_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
-                account2.address,
-                ConfNetworkType,
-            );
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                done();
-            });
-            listener.status(account.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            transactionHttp.announce(secretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('HashType: Op_Hash_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('aggregate', (done) => {
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                0,
-                0,
-                [new MultisigCosignatoryModification(
-                    MultisigCosignatoryModificationType.Add,
-                    TestingAccount.publicAccount,
-                )],
-                ConfNetworkType,
-                );
-            const aggregateTransaction = AggregateTransaction.createBonded(Deadline.create(20, ChronoUnit.MINUTES),
-                [modifyMultisigAccountTransaction.toAggregate(MultisigAccount.publicAccount)],
-                ConfNetworkType,
-                []);
-
-            const signedTransaction = CosignatoryAccount.signTransactionWithCosignatories(
-                aggregateTransaction,
-                [Cosignatory2Account],
-                generationHash
-            );
-
-            const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-                new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10*1000000)),
-                UInt64.fromUint(10000),
-                signedTransaction,
-                ConfNetworkType);
-
-            setTimeout(() => {
-                transactionHttp.announce(lockFundsTransaction.signWith(CosignatoryAccount, generationHash));
-            }, 1000);
-
-            validateTransactionAnnounceCorrectly(CosignatoryAccount.address, () => {
-                validatePartialTransactionAnnounceCorrectly(CosignatoryAccount.address, done);
-                setTimeout(() => {
-                    transactionHttp.announceAggregateBonded(signedTransaction);
-                }, 1000);
-            });
-            transactionHttp.announce(aggregateSecretLockTransaction.signWith(account, generationHash));
-        });
-    });
-    describe('SecretProofTransaction - HashType: Op_Sha3_256', () => {
-        it('CosignatureTransaction', (done) => {
-            const transferTransaction = TransferTransaction.create(
-                Deadline.create(),
-                TestingRecipient.address,
-                [new Mosaic(ConfNetworkMosaic, UInt64.fromUint(1))],
-                PlainMessage.create('test-message'),
-                ConfNetworkType,
-            );
-            const aggregateTransaction = AggregateTransaction.createBonded(
-                Deadline.create(2, ChronoUnit.MINUTES),
-                [transferTransaction.toAggregate(MultisigAccount.publicAccount)],
-                ConfNetworkType,
-                []);
-
-            const signedTransaction = aggregateTransaction.signWith(
-                CosignatoryAccount, generationHash
-            );
-
-            const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-                new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                UInt64.fromUint(10000),
-                signedTransaction,
-                ConfNetworkType);
-
-            setTimeout(() => {
-                transactionHttp.announce(lockFundsTransaction.signWith(CosignatoryAccount, generationHash));
-            }, 1000);
-
-            validateTransactionAnnounceCorrectly(CosignatoryAccount.address, () => {
-                setTimeout(() => {
-                    transactionHttp.announceAggregateBonded(signedTransaction);
-                }, 1000);
-
-                validateCosignaturePartialTransactionAnnounceCorrectly(CosignatoryAccount.address, Cosignatory2Account.publicKey, done);
-                validatePartialTransactionNotPartialAnyMore(CosignatoryAccount.address, signedTransaction.hash, done);
-                validatePartialTransactionAnnounceCorrectly(CosignatoryAccount.address, () => {
-                    accountHttp.aggregateBondedTransactions(CosignatoryAccount.publicAccount).subscribe((transactions) => {
-                        const partialTransaction = transactions[0];
-                        const cosignatureTransaction = CosignatureTransaction.create(partialTransaction);
-                        const cosignatureSignedTransaction = Cosignatory2Account.signCosignatureTransaction(cosignatureTransaction);
-                        transactionHttp.announceAggregateBondedCosignature(cosignatureSignedTransaction);
-                    });
-                });
-                const secretProofTransaction = SecretProofTransaction.create(
+        describe('HashType: Op_Sha3_256', () => {
+            it('standalone', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
                     Deadline.create(),
-                    [],
-                    ConfNetworkType,
-                    [],
-                );
-                const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
-
-                const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-                new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                UInt64.fromUint(10000),
-                    signedTransaction,
-                    ConfNetworkType);
-
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                transactionHttp.announce(lockFundsTransaction.signWith(TestingAccount, generationHash));
-            });
-            listener.status(account2.address).subscribe((error) => {
-                console.log('Error:', error);
-                assert(false);
-                done();
-            });
-            const signedSecretLockTx = secretLockTransaction.signWith(account, generationHash);
-            transactionHttp.announce(signedSecretLockTx);
-        });
-    });
-
-    describe('SecretProofTransaction - HashType: Op_Sha3_256', () => {
-        let listener: Listener;
-        before (() => {
-            listener = new Listener(APIUrl);
-            return listener.open();
-        });
-        after(() => {
-            return listener.close();
-        });
-        it('aggregate', (done) => {
-            const secretSeed = Crypto.randomBytes(20);
-            const secret = sha3_256.create().update(secretSeed).hex();
-            const proof = convert.uint8ToHex(secretSeed);
-            const secretLockTransaction = SecretLockTransaction.create(
-                Deadline.create(),
-                NetworkCurrencyMosaic.createAbsolute(10),
-                UInt64.fromUint(100),
-                HashType.Op_Sha3_256,
-                secret,
-                account2.address,
-                ConfNetworkType,
-            );
-            listener.confirmed(account.address).subscribe((transaction: Transaction) => {
-                listener.confirmed(account2.address).subscribe((transaction: Transaction) => {
-                    done();
-                });
-                const secretProofTransaction = SecretProofTransaction.create(
-                    Deadline.create(),
-                    [],
-                    ConfNetworkType,
-                    [],
-                );
-                const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
-                const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
                     new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                    UInt64.fromUint(10),
-                    signedTransaction,
-                    ConfNetworkType);
-                const aggregateLockFundsTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                    [lockFundsTransaction.toAggregate(TestingAccount.publicAccount)],
+                    UInt64.fromUint(100),
+                    HashType.Op_Sha3_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Sha3_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                    [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
                     ConfNetworkType,
                     []);
-                validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                transactionHttp.announce(aggregateLockFundsTransaction.signWith(TestingAccount, generationHash));
+                const signedTransaction = aggregateSecretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+        });
+        describe('HashType: Keccak_256', () => {
+            it('standalone', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Keccak_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Keccak_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                    [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
+                    ConfNetworkType,
+                    []);
+                const signedTransaction = aggregateSecretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+        });
+
+        describe('HashType: Op_Hash_160', () => {
+            it('standalone', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_160,
+                    sha3_256.create().update(randomBytes(20)).hex().substr(0, 40),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_160,
+                    sha3_256.create().update(randomBytes(20)).hex().substr(0, 40),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                    [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
+                    ConfNetworkType,
+                    []);
+                const signedTransaction = aggregateSecretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+        });
+
+        describe('HashType: Op_Hash_256', () => {
+            it('standalone', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_256,
+                    sha3_256.create().update(randomBytes(20)).hex(),
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                    [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
+                    ConfNetworkType,
+                    []);
+                const signedTransaction = aggregateSecretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
             });
         });
     });
-*/
-        describe('SecretLockTransaction', () => {
-            describe('HashType: Op_Sha3_256', () => {
-                it('standalone', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Sha3_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
 
-                it('aggregate', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Sha3_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                        [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
-                        ConfNetworkType,
-                        []);
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(aggregateSecretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-            describe('HashType: Keccak_256', () => {
-                it('standalone', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Keccak_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Keccak_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                        [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
-                        ConfNetworkType,
-                        []);
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(aggregateSecretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-
-            describe('HashType: Op_Hash_160', () => {
-                it('standalone', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_160,
-                        sha3_256.create().update(randomBytes(20)).hex().substr(0, 40),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_160,
-                        sha3_256.create().update(randomBytes(20)).hex().substr(0, 40),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                        [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
-                        ConfNetworkType,
-                        []);
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(aggregateSecretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-
-            describe('HashType: Op_Hash_256', () => {
-                it('standalone', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_256,
-                        sha3_256.create().update(randomBytes(20)).hex(),
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    const aggregateSecretLockTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                        [secretLockTransaction.toAggregate(TestingAccount.publicAccount)],
-                        ConfNetworkType,
-                        []);
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, done);
-                    transactionHttp.announce(aggregateSecretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-
-        });
-
-        describe('SecretProofTransaction', () => {
-            describe('HashType: Op_Sha3_256', () => {
-                it('standalone', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const secret = sha3_256.create().update(secretSeed).hex();
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Sha3_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
+    describe('SecretProofTransaction', () => {
+        describe('HashType: Op_Sha3_256', () => {
+            it('standalone', (done) => {
+                const secretSeed = randomBytes(20);
+                const secret = sha3_256.create().update(secretSeed).hex();
+                const proof = convert.uint8ToHex(secretSeed);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Sha3_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
                         const secretProofTransaction = SecretProofTransaction.create(
                             Deadline.create(),
                             HashType.Op_Sha3_256,
@@ -1237,26 +781,36 @@ describe('TransactionHttp', () => {
                             proof,
                             ConfNetworkType,
                         );
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(secretProofTransaction.signWith(TestingRecipient, generationHash));
+                        const signedSecretProofTransaction = secretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
                     });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
 
-                it('aggregate', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const secret = sha3_256.create().update(secretSeed).hex();
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Sha3_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
+            it('aggregate', (done) => {
+                const secretSeed = randomBytes(20);
+                const secret = sha3_256.create().update(secretSeed).hex();
+                const proof = convert.uint8ToHex(secretSeed);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Sha3_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
                         const secretProofTransaction = SecretProofTransaction.create(
                             Deadline.create(),
                             HashType.Op_Sha3_256,
@@ -1269,219 +823,287 @@ describe('TransactionHttp', () => {
                             [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
                             ConfNetworkType,
                             []);
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-            describe('HashType: Op_Keccak_256', () => {
-                it('standalone', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const secret = keccak_256.create().update(secretSeed).hex();
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Keccak_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                        );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Keccak_256,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(secretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const secret = keccak_256.create().update(secretSeed).hex();
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Keccak_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                        );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Keccak_256,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
-                            ConfNetworkType,
-                            []);
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-
-            describe('HashType: Op_Hash_160', () => {
-                it('standalone', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secret = CryptoJS.RIPEMD160(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_160,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Hash_160,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(secretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secret = CryptoJS.RIPEMD160(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_160,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                    );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Hash_160,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
-                            ConfNetworkType,
-                            []);
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-            });
-
-            describe('HashType: Op_Hash_256', () => {
-                it('standalone', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secret = CryptoJS.SHA256(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                        );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Hash_256,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(secretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
-
-                it('aggregate', (done) => {
-                    const secretSeed = randomBytes(20);
-                    const proof = convert.uint8ToHex(secretSeed);
-                    const secret = CryptoJS.SHA256(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
-                    const secretLockTransaction = SecretLockTransaction.create(
-                        Deadline.create(),
-                        new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
-                        UInt64.fromUint(100),
-                        HashType.Op_Hash_256,
-                        secret,
-                        TestingRecipient.address,
-                        ConfNetworkType,
-                        );
-                    validateTransactionAnnounceCorrectly(TestingAccount.address, () => {
-                        const secretProofTransaction = SecretProofTransaction.create(
-                            Deadline.create(),
-                            HashType.Op_Hash_256,
-                            secret,
-                            TestingRecipient.address,
-                            proof,
-                            ConfNetworkType,
-                        );
-                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
-                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
-                            ConfNetworkType,
-                            []);
-                        validateTransactionAnnounceCorrectly(TestingRecipient.address, done);
-                        transactionHttp.announce(aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash));
-                    });
-                    transactionHttp.announce(secretLockTransaction.signWith(TestingAccount, generationHash));
-                });
+                        const signedAggregateSecretProofTransaction = aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedAggregateSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedAggregateSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    })
+                transactionHttp.announce(signedSecretLockTransaction);
             });
         });
+        describe('HashType: Op_Keccak_256', () => {
+            it('standalone', (done) => {
+                const secretSeed = randomBytes(20);
+                const secret = keccak_256.create().update(secretSeed).hex();
+                const proof = convert.uint8ToHex(secretSeed);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Keccak_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Keccak_256,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const signedSecretProofTransaction = secretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    });
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretSeed = randomBytes(20);
+                const secret = keccak_256.create().update(secretSeed).hex();
+                const proof = convert.uint8ToHex(secretSeed);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Keccak_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Keccak_256,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
+                            ConfNetworkType,
+                            []);
+                        const signedAggregateSecretProofTransaction = aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedAggregateSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedAggregateSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    })
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+        });
+
+        describe('HashType: Op_Hash_160', () => {
+            it('standalone', (done) => {
+                const secretSeed = randomBytes(20);
+                const proof = convert.uint8ToHex(secretSeed);
+                const secret = CryptoJS.RIPEMD160(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_160,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Hash_160,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const signedSecretProofTransaction = secretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    });
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretSeed = randomBytes(20);
+                const proof = convert.uint8ToHex(secretSeed);
+                const secret = CryptoJS.RIPEMD160(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_160,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Hash_160,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
+                            ConfNetworkType,
+                            []);
+                        const signedAggregateSecretProofTransaction = aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedAggregateSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedAggregateSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    })
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+        });
+
+        describe('HashType: Op_Hash_256', () => {
+            it('standalone', (done) => {
+                const secretSeed = randomBytes(20);
+                const proof = convert.uint8ToHex(secretSeed);
+                const secret = CryptoJS.SHA256(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Hash_256,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const signedSecretProofTransaction = secretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    });
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const secretSeed = randomBytes(20);
+                const proof = convert.uint8ToHex(secretSeed);
+                const secret = CryptoJS.SHA256(CryptoJS.enc.Hex.parse(CryptoJS.SHA256(CryptoJS.enc.Hex.parse(proof)).toString(CryptoJS.enc.Hex))).toString(CryptoJS.enc.Hex);
+                const secretLockTransaction = SecretLockTransaction.create(
+                    Deadline.create(),
+                    new Mosaic(ConfNetworkMosaic, UInt64.fromUint(10 * 1000000)),
+                    UInt64.fromUint(100),
+                    HashType.Op_Hash_256,
+                    secret,
+                    TestingRecipient.address,
+                    ConfNetworkType,
+                );
+                const signedSecretLockTransaction = secretLockTransaction.signWith(TestingAccount, generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedSecretLockTransaction.hash)
+                    .then(() => {
+                        const secretProofTransaction = SecretProofTransaction.create(
+                            Deadline.create(),
+                            HashType.Op_Hash_256,
+                            secret,
+                            TestingRecipient.address,
+                            proof,
+                            ConfNetworkType,
+                        );
+                        const aggregateSecretProofTransaction = AggregateTransaction.createComplete(Deadline.create(),
+                            [secretProofTransaction.toAggregate(TestingRecipient.publicAccount)],
+                            ConfNetworkType,
+                            []);
+                        const signedAggregateSecretProofTransaction = aggregateSecretProofTransaction.signWith(TestingRecipient, generationHash);
+                        validateTransactionConfirmed(listener, TestingRecipient.address, signedAggregateSecretProofTransaction.hash)
+                            .then(() => {
+                                done();
+                            }, (reason) => {
+                                fail(reason);
+                            });
+                        transactionHttp.announce(signedAggregateSecretProofTransaction);
+                    }, (reason) => {
+                        fail(reason);
+                    })
+                transactionHttp.announce(signedSecretLockTransaction);
+            });
+        });
+    });
 
     describe('getTransaction', () => {
         it('should return transaction info given transactionHash', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransaction(data.testTxHash)
-                .subscribe((transaction) => {
-                    expect(transaction.transactionInfo!.hash).to.be.equal(data.testTxHash);
-                    expect(transaction.transactionInfo!.id).to.be.equal(data.testTxId);
-                    done();
-                });
+                    .subscribe((transaction) => {
+                        expect(transaction.transactionInfo!.hash).to.be.equal(data.testTxHash);
+                        expect(transaction.transactionInfo!.id).to.be.equal(data.testTxId);
+                        done();
+                    });
             })
         });
 
         it('should return transaction info given transactionId', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransaction(data.testTxId)
-                .subscribe((transaction) => {
-                    expect(transaction.transactionInfo!.hash).to.be.equal(data.testTxHash);
-                    expect(transaction.transactionInfo!.id).to.be.equal(data.testTxId);
-                    done();
-                });
+                    .subscribe((transaction) => {
+                        expect(transaction.transactionInfo!.hash).to.be.equal(data.testTxHash);
+                        expect(transaction.transactionInfo!.id).to.be.equal(data.testTxId);
+                        done();
+                    });
             });
         });
     });
@@ -1490,22 +1112,22 @@ describe('TransactionHttp', () => {
         it('should return transaction info given array of transactionHash', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransactions([data.testTxHash])
-                .subscribe((transactions) => {
-                    expect(transactions[0].transactionInfo!.hash).to.be.equal(data.testTxHash);
-                    expect(transactions[0].transactionInfo!.id).to.be.equal(data.testTxId);
-                    done();
-                });
+                    .subscribe((transactions) => {
+                        expect(transactions[0].transactionInfo!.hash).to.be.equal(data.testTxHash);
+                        expect(transactions[0].transactionInfo!.id).to.be.equal(data.testTxId);
+                        done();
+                    });
             });
         });
 
         it('should return transaction info given array of transactionId', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransactions([data.testTxId])
-                .subscribe((transactions) => {
-                    expect(transactions[0].transactionInfo!.hash).to.be.equal(data.testTxHash);
-                    expect(transactions[0].transactionInfo!.id).to.be.equal(data.testTxId);
-                    done();
-                });
+                    .subscribe((transactions) => {
+                        expect(transactions[0].transactionInfo!.hash).to.be.equal(data.testTxHash);
+                        expect(transactions[0].transactionInfo!.id).to.be.equal(data.testTxId);
+                        done();
+                    });
             });
         });
     });
@@ -1514,12 +1136,12 @@ describe('TransactionHttp', () => {
         it('should return transaction status given array transactionHash', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransactionStatus(data.testTxHash)
-                .subscribe((transactionStatus) => {
-                    expect(transactionStatus.group).to.be.equal('confirmed');
-                    expect(transactionStatus.height!.lower).to.be.greaterThan(0);
-                    expect(transactionStatus.height!.higher).to.be.equal(0);
-                    done();
-                });
+                    .subscribe((transactionStatus) => {
+                        expect(transactionStatus.group).to.be.equal('confirmed');
+                        expect(transactionStatus.height!.lower).to.be.greaterThan(0);
+                        expect(transactionStatus.height!.higher).to.be.equal(0);
+                        done();
+                    });
             });
         });
     });
@@ -1528,12 +1150,12 @@ describe('TransactionHttp', () => {
         it('should return transaction status given array of transactionHash', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransactionsStatuses([data.testTxHash])
-                .subscribe((transactionStatuses) => {
-                    expect(transactionStatuses[0].group).to.be.equal('confirmed');
-                    expect(transactionStatuses[0].height!.lower).to.be.greaterThan(0);
-                    expect(transactionStatuses[0].height!.higher).to.be.equal(0);
-                    done();
-                });
+                    .subscribe((transactionStatuses) => {
+                        expect(transactionStatuses[0].group).to.be.equal('confirmed');
+                        expect(transactionStatuses[0].height!.lower).to.be.greaterThan(0);
+                        expect(transactionStatuses[0].height!.higher).to.be.equal(0);
+                        done();
+                    });
             });
         });
     });
@@ -1599,32 +1221,6 @@ describe('TransactionHttp', () => {
         });
     });
 
-    describe('aggregate complete tx', () => {
-        it('should work', () => {
-            const tx = TransferTransaction.create(
-                Deadline.create(),
-                TestingRecipient.address,
-                [],
-                PlainMessage.create('Hi'),
-                ConfNetworkType,
-            );
-            const aggTx = AggregateTransaction.createComplete(
-                Deadline.create(),
-                [
-                    tx.toAggregate(TestingAccount.publicAccount),
-                ],
-                ConfNetworkType,
-                [],
-            );
-            const signedTx = TestingAccount.sign(aggTx, generationHash);
-            const trnsHttp = new TransactionHttp(APIUrl);
-            trnsHttp.announce(signedTx)
-                .subscribe((res) => {
-                    console.log('res', res);
-                });
-        });
-    });
-
     describe('announceSync', () => {
         it('should return insufficient balance error', (done) => {
             const signerAccount = TestingAccount;
@@ -1655,39 +1251,42 @@ describe('TransactionHttp', () => {
         it('should return effective paid fee given transactionHash', (done) => {
             GetNemesisBlockDataPromise().then((data) => {
                 transactionHttp.getTransactionEffectiveFee(data.testTxHash)
-                .subscribe((effectiveFee) => {
-                    expect(effectiveFee).to.not.be.undefined;
-                    expect(effectiveFee).to.be.equal(0);
-                    done();
-                });
+                    .subscribe((effectiveFee) => {
+                        expect(effectiveFee).to.not.be.undefined;
+                        expect(effectiveFee).to.be.equal(0);
+                        done();
+                    });
             });
         });
     });
-    // describe('announceSync', () => {
-    //     it('should return insufficient balance error', (done) => {
-    //         const aggregateTransaction = AggregateTransaction.createBonded(
-    //                         Deadline.create(),
-    //                         [],
-    //                         ConfNetworkType,
-    //                         [],
-    //                     );
-    //         const signedTransaction = account.sign(aggregateTransaction);
 
-    //         const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
-    //             NetworkCurrencyMosaic.createAbsolute(0),
-    //             UInt64.fromUint(10000),
-    //             signedTransaction,
-    //             ConfNetworkType);
+    describe('announceSync', () => {
+         it('should return insufficient balance error', (done) => {
+             const aggregateTransaction = AggregateTransaction.createBonded(
+                            Deadline.create(),
+                             [],
+                             ConfNetworkType,
+                             [],
+                         );
+             const signedTransaction = TestingAccount.sign(aggregateTransaction, generationHash);
 
-    //         transactionHttp
-    //             .announceSync(lockFundsTransaction.signWith(account, generationHash))
-    //             .subscribe((shouldNotBeCalled) => {
-    //                 throw new Error('should not be called');
-    //             }, (err) => {
-    //                 console.log(err);
-    //                 expect(err.status).to.be.equal('Failure_LockHash_Invalid_Mosaic_Amount');
-    //                 done();
-    //             });
-    //     });
-    // });
+             const lockFundsTransaction = LockFundsTransaction.create(Deadline.create(),
+                 new Mosaic(ConfNetworkMosaic, UInt64.fromUint(0)),
+                 UInt64.fromUint(10000),
+                 signedTransaction,
+                 ConfNetworkType);
+
+             const signedLockFundsTransactions = lockFundsTransaction.signWith(TestingAccount, generationHash);
+
+             validateTransactionConfirmed(listener, TestingAccount.address, signedLockFundsTransactions.hash)
+                .then(() => {
+                    fail('should not be called');
+                }).catch((reason) => {
+                    expect(reason.status).to.be.equal('Failure_LockHash_Invalid_Mosaic_Amount');
+                    done();
+                });
+
+             transactionHttp.announce(signedLockFundsTransactions);
+         });
+     });
 });

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/e2e/utils/utils.ts
+++ b/e2e/utils/utils.ts
@@ -1,0 +1,52 @@
+import { Listener } from "../../src/infrastructure/Listener";
+import { Address, Transaction } from "../../src/model/model";
+
+export const validateTransactionConfirmed = (listener: Listener, address: Address,  hash: string) => {
+    return new Promise((resolve, reject) => {
+        const status = listener.status(address).subscribe(error => {
+            if (error && hash && error.hash === hash) {
+                console.error(error);
+                status.unsubscribe();
+                sub.unsubscribe();
+                reject(error);
+            }
+        });
+        const sub = listener.confirmed(address).subscribe((transaction: Transaction) => {
+            if (transaction && transaction.transactionInfo && transaction.transactionInfo.hash === hash) {
+                // console.log(transaction);
+                status.unsubscribe();
+                sub.unsubscribe();
+                resolve();
+            }
+        });
+    });
+
+    // TODO: improve
+    const validatePartialTransactionAnnounceCorrectly = (address: Address, done) => {
+        const sub = listener.aggregateBondedAdded(address).subscribe((transaction: Transaction) => {
+            sub.unsubscribe();
+            return done();
+        });
+    }
+
+    // TODO: improve
+    const validateCosignaturePartialTransactionAnnounceCorrectly = (address: Address, publicKey, done) => {
+        const sub = listener.cosignatureAdded(address).subscribe((signature) => {
+            if (signature.signer === publicKey) {
+                sub.unsubscribe();
+                return done();
+            }
+        });
+    }
+
+    // TODO: improve
+    const validatePartialTransactionNotPartialAnyMore = (address: Address, hash: string, done) => {
+        const sub = listener.aggregateBondedRemoved(address).subscribe(txhash => {
+            if (txhash === hash) {
+                sub.unsubscribe();
+                return done();
+            }
+        });
+    }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,143 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
-    "@babel/highlight": {
+    "@babel/generator": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@types/caseless": {
@@ -42,43 +162,53 @@
       "integrity": "sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ==",
       "dev": true
     },
-    "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.48",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
-      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.49",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
-      "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "version": "2.48.2",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.2.tgz",
+      "integrity": "sha512-gP+PSFXAXMrd5PcD7SqHeUjdGshAI8vKQ3+AvpQr3ht9iQea+59LOKvKITcQI+Lg+1EIkDP6AFSBUJPWG8GDyA==",
       "dev": true,
       "requires": {
         "@types/caseless": "*",
-        "@types/form-data": "*",
         "@types/node": "*",
-        "@types/tough-cookie": "*"
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
+          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@types/request-promise-native": {
@@ -103,11 +233,12 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-3.2.1.tgz",
-      "integrity": "sha512-t5n0/iHoavnX1MqeYmKJgWc1W6yX4BXsNxQg7M5862RWrfN9S5k8yaWbDMGJSTCzbH7+q5QS8chjymd+ND9gMw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.1.tgz",
+      "integrity": "sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==",
       "dev": true,
       "requires": {
+        "@types/events": "*",
         "@types/node": "*"
       }
     },
@@ -129,6 +260,18 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -137,6 +280,21 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "arg": {
       "version": "4.1.0",
@@ -162,12 +320,15 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+      "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
       "dev": true,
       "requires": {
-        "util": "0.10.3"
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
       }
     },
     "assert-plus": {
@@ -231,9 +392,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buffer-from": {
@@ -246,6 +407,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "caching-transform": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "dev": true,
+      "requires": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "caseless": {
@@ -278,12 +457,6 @@
         "supports-color": "^5.3.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -301,13 +474,30 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -325,9 +515,15 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
@@ -337,12 +533,21 @@
       "dev": true
     },
     "config": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.1.0.tgz",
-      "integrity": "sha512-t6oDeNQbsIWa+D/KF4959TANzjSHLv1BA/hvL8tHEA3OUSWgBXELKaONSI6nr9oanbKs0DXonjOWLcrtZ3yTAA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.2.2.tgz",
+      "integrity": "sha512-rOsfIOAcG82AWouK4/vBS/OKz3UPl2T/kP0irExmXJJOoWg2CmdfPLdx56bCoMUMFNh+7soQkQWCUC8DyemiwQ==",
       "dev": true,
       "requires": {
         "json5": "^1.0.1"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
       }
     },
     "core-util-is": {
@@ -351,17 +556,43 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
-      "integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.5.tgz",
+      "integrity": "sha512-/KD7PGfZv/tjKB6LoW97jzIgFqem0Tu9tZL9/iwBnBd8zkIZp7vT1ZSHNvnr0GSQMV/LTMxUstWg8WcDDUVQKg==",
       "dev": true,
       "requires": {
         "growl": "~> 1.10.0",
-        "js-yaml": "^3.11.0",
+        "js-yaml": "^3.13.1",
         "lcov-parse": "^0.0.10",
         "log-driver": "^1.2.7",
         "minimist": "^1.2.0",
         "request": "^2.86.0"
+      }
+    },
+    "cp-file": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^2.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^4.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-js": {
@@ -378,13 +609,19 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -395,15 +632,33 @@
         "type-detect": "^4.0.0"
       }
     },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "ecc-jsbn": {
@@ -414,6 +669,67 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -433,6 +749,21 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -448,10 +779,61 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flatbuffers": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.11.0.tgz",
       "integrity": "sha512-0PqFKtXI4MjxomI7jO4g5XfLPm/15g2R+5WGCHBGYGh0ihQiypnHlJ6bMmkkrAe0GzZ4d7PDAfCONKIPUxNF+A=="
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        }
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -484,11 +866,32 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -499,9 +902,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -512,11 +915,43 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -532,10 +967,25 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hash-base": {
@@ -547,10 +997,25 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-signature": {
@@ -562,6 +1027,12 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -578,20 +1049,206 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
+    "is-nan": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+      "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.1"
+      }
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
+    },
     "js-joda": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/js-joda/-/js-joda-1.10.1.tgz",
-      "integrity": "sha512-lDBKliZf2oLX4h1EjzkhBulpQRv51A9x2nhX1XnP1PD0LU7a30I7CKtAWZ//5c+Z6aWG8TO996vVr+4owE9vWA=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/js-joda/-/js-joda-1.11.0.tgz",
+      "integrity": "sha512-/HJpRhwP2fPyuSsCaZuoVJuaSIt8tUXykV4wOMRXrFk7RP9h9VWaFdS9YHKdMepxb/3TdXpL6IhfC9L0sqYVBw=="
     },
     "js-sha256": {
       "version": "0.9.0",
@@ -623,6 +1280,18 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -659,16 +1328,61 @@
         "verror": "1.10.0"
       }
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
     "lcov-parse": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.7",
@@ -676,11 +1390,77 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      }
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "mime-db": {
       "version": "1.40.0",
@@ -694,6 +1474,12 @@
       "requires": {
         "mime-db": "1.40.0"
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -728,2673 +1514,180 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.3.1",
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-          "dev": true
-        }
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nyc": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
-      "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
+        "caching-transform": "^3.0.2",
+        "convert-source-map": "^1.6.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
         "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
-        "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
-      },
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "^1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "atob": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.22.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cache-base": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "collection-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
-          }
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.6",
-          "bundled": true,
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-cache": "^0.2.2"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "has-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "has-values": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "^0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "^1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-visit": "^1.0.0"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "nanomatch": {
-          "version": "1.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
-          }
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "bundled": true,
-          "dev": true
-        },
-        "regex-not": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ret": {
-          "version": "0.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-regex": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ret": "~0.1.10"
-          }
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-value": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.0"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "bundled": true,
-              "dev": true
-            },
-            "braces": {
-              "version": "2.3.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "2.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "0.2.5",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^0.1.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                },
-                "is-accessor-descriptor": {
-                  "version": "0.1.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-data-descriptor": {
-                  "version": "0.1.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-descriptor": {
-                  "version": "0.1.6",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
-                  }
-                },
-                "kind-of": {
-                  "version": "5.1.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "extglob": {
-              "version": "2.0.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^1.0.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "fill-range": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "micromatch": {
-              "version": "3.1.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
-              }
-            }
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "to-object-path": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            }
-          }
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "union-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
-              }
-            }
-          }
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
-              },
-              "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-values": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "use": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        }
+        "test-exclude": "^5.2.3",
+        "uuid": "^3.3.2",
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
       }
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -3405,10 +1698,121 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -3416,6 +1820,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -3428,10 +1849,41 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
     "psl": {
       "version": "1.1.33",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
       "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -3442,6 +1894,36 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
     },
     "request": {
       "version": "2.88.0",
@@ -3495,13 +1977,40 @@
         "tough-cookie": "^2.3.3"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -3514,17 +2023,17 @@
       }
     },
     "rxjs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-      "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "rxjs-compat": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.2.1.tgz",
-      "integrity": "sha512-Pst0lkAwVodBbBOIZic9aM1vY9asJ2u8GfKN115+goIH83PAlizJDyvixuxPAuQ1UtkmBuro7+0PqKQ3PSkhEg=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.5.2.tgz",
+      "integrity": "sha512-TRMkTp4FgSxE2HtGvxmgRukh3JqdFM7ejAj1Ti/VdodbPGfWvZR5+KdLKRV9jVDFyu2SknM8RD+PR54KGnoLjg=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -3537,15 +2046,48 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "secure-random": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
+      "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ==",
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-support": {
@@ -3565,6 +2107,52 @@
           "dev": true
         }
       }
+    },
+    "spawn-wrap": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3593,14 +2181,69 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
-    "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -3618,10 +2261,16 @@
         }
       }
     },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
     "ts-mockito": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.3.1.tgz",
-      "integrity": "sha512-chcKw0sTApwJxTyKhzbWxI4BTUJ6RStZKUVh2/mfwYqFS09PYy5pvdXZwG35QSkqT5pkdXZlYKBX196RRvEZdQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.4.2.tgz",
+      "integrity": "sha512-3AqLVXxjfdwlo2eC+xrzFsc5rsPtKBBhJZAnxWmyBmgT/PC+K26RIxiT2QLKcqjcJqZnuGZkwfPMx2gN31lFnw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5"
@@ -3649,14 +2298,14 @@
       }
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz",
-      "integrity": "sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
+      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3665,21 +2314,13 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true
-        }
       }
     },
     "tsutils": {
@@ -3711,9 +2352,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "typescript-require": {
@@ -3733,6 +2374,26 @@
         }
       }
     },
+    "uglify-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -3742,23 +2403,27 @@
       }
     },
     "utf8": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       },
       "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
           "dev": true
         }
       }
@@ -3767,6 +2432,16 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "verror": {
       "version": "1.10.0",
@@ -3778,18 +2453,230 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+      "integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
+      "requires": {
+        "async-limiter": "^1.0.0"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "yn": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Proximax Blockchain sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",
-    "test": "mocha --ui bdd --recursive ./dist/test --timeout 90000",
-    "test:e2e": "npm run build && mocha --ui bdd --recursive ./dist/e2e --timeout 90000",
-    "test:all": "mocha --ui bdd --recursive ./dist/ --timeout 90000",
-    "build": "rm -rf dist/ && tsc",
+    "test": "mocha --ui bdd --require ts-node/register './test/**/*.spec.*' --timeout 90000",
+    "test:e2e": "npm run build && mocha --ui bdd --require ts-node/register './e2e/**/*.spec.*' --timeout 90000",
+    "test:all": "mocha --ui bdd --require ts-node/register './test/**/*.spec.*' './e2e/**/*.spec.*' --timeout 90000",
+    "build": "rm -rf dist && tsc",
+    "test:covhtml": "nyc npm t && nyc report --reporter=html --reporter=text-summary",
     "test:cov": "nyc --reporter=lcov --reporter=text-lcov npm t && nyc report --reporter=text-lcov",
     "test:coveralls": "npm run test:cov | coveralls"
   },
@@ -30,53 +31,60 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "devDependencies": {
-    "@types/chai": "^4.0.4",
+    "@types/chai": "^4.1.7",
     "@types/crypto-js": "^3.1.43",
-    "@types/lodash": "^4.14.85",
-    "@types/mocha": "^2.2.44",
-    "@types/node": "^8.0.0",
-    "@types/request": "^2.47.0",
-    "@types/request-promise-native": "^1.0.14",
+    "@types/lodash": "^4.14.136",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.6.8",
+    "@types/request": "^2.48.2",
+    "@types/request-promise-native": "^1.0.16",
     "@types/utf8": "^2.1.6",
-    "@types/ws": "^3.2.0",
-    "assert": "^1.4.1",
-    "chai": "^4.1.2",
-    "config": "^3.1.0",
-    "coveralls": "^3.0.0",
-    "mocha": "^4.0.1",
-    "nyc": "^11.3.0",
-    "secure-random": "^1.1.1",
-    "ts-mockito": "^2.2.7",
-    "ts-node": "^8.2.0",
-    "tslint": "^5.8.0",
-    "typescript": "^3.4.4",
-    "typescript-require": "^0.2.9-1"
+    "@types/ws": "^6.0.1",
+    "assert": "^2.0.0",
+    "chai": "^4.2.0",
+    "config": "^3.2.2",
+    "coveralls": "^3.0.5",
+    "mocha": "^6.2.0",
+    "nyc": "^14.1.1",
+    "secure-random": "^1.1.2",
+    "ts-mockito": "^2.4.2",
+    "ts-node": "^8.3.0",
+    "tslint": "^5.18.0",
+    "typescript": "^3.5.3",
+    "typescript-require": "^0.2.10"
   },
   "dependencies": {
     "bluebird": "^3.5.5",
     "crypto-js": "^3.1.9-1",
     "flatbuffers": "^1.11.0",
-    "js-joda": "^1.6.2",
+    "js-joda": "^1.11.0",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0",
     "ripemd160": "^2.0.2",
-    "request": "^2.83.0",
-    "request-promise-native": "^1.0.5",
-    "rxjs": "^6.2.1",
-    "rxjs-compat": "^6.2.1",
-    "utf8": "^2.1.2",
-    "ws": "^5.2.0"
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.7",
+    "rxjs": "^6.5.2",
+    "rxjs-compat": "^6.5.2",
+    "utf8": "^3.0.0",
+    "ws": "^7.1.1"
   },
   "peerDependencies": {},
-  "nyc": {
-    "exclude": [
-      "**/*.spec.js"
-    ]
-  },
   "files": [
-    "dist/index*",
+    "dist/index.*",
     "dist/src"
   ],
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "src"
+    ],
+    "exclude": [],
+    "sourceMap": true,
+    "instrument": true,
+    "all": true
+  },
   "keywords": [
     "xpx",
     "proximax",

--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -113,7 +113,7 @@ export class AccountHttp extends Http implements AccountRepository {
         };
         return observableFrom(
             this.accountRoutesApi.getAccountRestrictionsFromAccounts(accountIds))
-                .pipe(map((accountRestrictions: AccountRestrictionsDTO[]) => {
+                .pipe(map((accountRestrictions: AccountRestrictionsInfoDTO[]) => {
             return accountRestrictions.map((restriction) => {
                 return DtoMapping.extractAccountRestrictionFromDto(restriction);
             });

--- a/src/infrastructure/api/accountRoutesApi.ts
+++ b/src/infrastructure/api/accountRoutesApi.ts
@@ -95,7 +95,7 @@ export class AccountRoutesApi {
      * @summary Get account information
      * @param accountId The public key or address of the account.
      */
-    public async getAccountInfo(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: AccountInfoDTO; }> {
+    public async getAccountInfo(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<AccountInfoDTO> {
         const localVarPath = this.basePath + '/account/{accountId}'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
         let localVarQueryParameters: any = {};
@@ -129,7 +129,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AccountInfoDTO; }>((resolve, reject) => {
+        return new Promise<AccountInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -152,7 +152,7 @@ export class AccountRoutesApi {
      * @summary Get multisig account information
      * @param accountId The public key or address of the account.
      */
-    public async getAccountMultisig(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: MultisigAccountInfoDTO; }> {
+    public async getAccountMultisig(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<MultisigAccountInfoDTO> {
         const localVarPath = this.basePath + '/account/{accountId}/multisig'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
         let localVarQueryParameters: any = {};
@@ -186,7 +186,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: MultisigAccountInfoDTO; }>((resolve, reject) => {
+        return new Promise<MultisigAccountInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -209,7 +209,7 @@ export class AccountRoutesApi {
      * @summary Get multisig account graph information
      * @param accountId The public key or address of the account.
      */
-    public async getAccountMultisigGraph(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<MultisigAccountGraphInfoDTO>; }> {
+    public async getAccountMultisigGraph(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<MultisigAccountGraphInfoDTO>> {
         const localVarPath = this.basePath + '/account/{accountId}/multisig/graph'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
         let localVarQueryParameters: any = {};
@@ -243,7 +243,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<MultisigAccountGraphInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<MultisigAccountGraphInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -266,7 +266,7 @@ export class AccountRoutesApi {
      * @summary Get the account restrictions
      * @param accountId The public key or address of the account.
      */
-    public async getAccountRestrictions (accountId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: AccountRestrictionsInfoDTO;  }> {
+    public async getAccountRestrictions (accountId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<AccountRestrictionsInfoDTO> {
         // const localVarPath = this.basePath + '/account/{accountId}/restrictions'
         const localVarPath = this.basePath + '/account/{accountId}/properties'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
@@ -301,7 +301,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AccountRestrictionsInfoDTO;  }>((resolve, reject) => {
+        return new Promise<AccountRestrictionsInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -324,7 +324,7 @@ export class AccountRoutesApi {
      * @summary Get account restrictions for given array of addresses
      * @param accountIds
      */
-    public async getAccountRestrictionsFromAccounts (accountIds: AccountIds, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<AccountRestrictionsInfoDTO>;  }> {
+    public async getAccountRestrictionsFromAccounts (accountIds: AccountIds, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<Array<AccountRestrictionsInfoDTO>> {
         // const localVarPath = this.basePath + '/account/restrictions';
         const localVarPath = this.basePath + '/account/properties';
         let localVarQueryParameters: any = {};
@@ -359,7 +359,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<AccountRestrictionsInfoDTO>;  }>((resolve, reject) => {
+        return new Promise<Array<AccountRestrictionsInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -382,7 +382,7 @@ export class AccountRoutesApi {
      * @summary Get accounts information
      * @param accountIds
      */
-    public async getAccountsInfo(accountIds: AccountIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<AccountInfoDTO>; }> {
+    public async getAccountsInfo(accountIds: AccountIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<AccountInfoDTO>> {
         const localVarPath = this.basePath + '/account';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -416,7 +416,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<AccountInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<AccountInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -439,7 +439,7 @@ export class AccountRoutesApi {
      * @summary Get readable names for a set of accountIds.
      * @param accountIds
      */
-    public async getAccountsNames(accountIds: AccountIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<AccountNamesDTO>; }> {
+    public async getAccountsNames(accountIds: AccountIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<AccountNamesDTO>> {
         const localVarPath = this.basePath + '/account/names';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -473,7 +473,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<AccountNamesDTO>; }>((resolve, reject) => {
+        return new Promise<Array<AccountNamesDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -499,7 +499,7 @@ export class AccountRoutesApi {
      * @param id The transaction id up to which transactions are returned.
      * @param ordering The ordering criteria: * -id - Descending order by id. * id - Ascending order by id.
      */
-    public async incomingTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async incomingTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/transactions/incoming'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -545,7 +545,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -571,7 +571,7 @@ export class AccountRoutesApi {
      * @param id The transaction id up to which transactions are returned.
      * @param ordering The ordering criteria: * -id - Descending order by id. * id - Ascending order by id.
      */
-    public async outgoingTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async outgoingTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/transactions/outgoing'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -617,7 +617,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -643,7 +643,7 @@ export class AccountRoutesApi {
      * @param id The transaction id up to which transactions are returned.
      * @param ordering The ordering criteria. * -id - Descending order by id. * id - Ascending order by id.
      */
-    public async partialTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async partialTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/transactions/partial'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -689,7 +689,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -715,7 +715,7 @@ export class AccountRoutesApi {
      * @param id The transaction id up to which transactions are returned.
      * @param ordering The ordering criteria: * -id - Descending order by id. * id - Ascending order by id.
      */
-    public async transactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async transactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/transactions'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -761,7 +761,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -787,7 +787,7 @@ export class AccountRoutesApi {
      * @param id The transaction id up to which transactions are returned.
      * @param ordering The ordering criteria. * -id - Descending order by id. * id - Ascending order by id.
      */
-    public async unconfirmedTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async unconfirmedTransactions(publicKey: string, pageSize?: number, id?: string, ordering?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/transactions/unconfirmed'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -833,7 +833,7 @@ export class AccountRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/blockRoutesApi.ts
+++ b/src/infrastructure/api/blockRoutesApi.ts
@@ -92,7 +92,7 @@ export class BlockRoutesApi {
      * @summary Get block information
      * @param height The height of the block.
      */
-    public async getBlockByHeight(height: number, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: BlockInfoDTO; }> {
+    public async getBlockByHeight(height: number, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<BlockInfoDTO> {
         const localVarPath = this.basePath + '/block/{height}'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)));
         let localVarQueryParameters: any = {};
@@ -126,7 +126,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: BlockInfoDTO; }>((resolve, reject) => {
+        return new Promise<BlockInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -149,7 +149,7 @@ export class BlockRoutesApi {
      * @summary Get receipts from a block
      * @param height The height of the block.
      */
-    public async getBlockReceipts(height: number, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: StatementsDTO; }> {
+    public async getBlockReceipts(height: number, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<StatementsDTO> {
         const localVarPath = this.basePath + '/block/{height}/receipts'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)));
         let localVarQueryParameters: any = {};
@@ -183,7 +183,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: StatementsDTO; }>((resolve, reject) => {
+        return new Promise<StatementsDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -208,7 +208,7 @@ export class BlockRoutesApi {
      * @param pageSize The number of transactions to return for each request.
      * @param id The transaction id up to which transactions are returned.
      */
-    public async getBlockTransactions(height: number, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async getBlockTransactions(height: number, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/block/{height}/transactions'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)));
         let localVarQueryParameters: any = {};
@@ -250,7 +250,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -274,7 +274,7 @@ export class BlockRoutesApi {
      * @param height The height of the block. If height -1 is not a multiple of the limit provided, the inferior closest multiple + 1 is used instead.
      * @param limit The number of blocks to be returned.
      */
-    public async getBlocksByHeightWithLimit(height: number, limit: 25 | 50 | 75 | 100, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<BlockInfoDTO>; }> {
+    public async getBlocksByHeightWithLimit(height: number, limit: 25 | 50 | 75 | 100, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<BlockInfoDTO>> {
         const localVarPath = this.basePath + '/blocks/{height}/limit/{limit}'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)))
             .replace('{' + 'limit' + '}', encodeURIComponent(String(limit)));
@@ -314,7 +314,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<BlockInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<BlockInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -338,7 +338,7 @@ export class BlockRoutesApi {
      * @param height The height of the block.
      * @param hash The hash of the receipt statement or resolution.
      */
-    public async getMerkleReceipts(height: number, hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: MerkleProofInfoDTO; }> {
+    public async getMerkleReceipts(height: number, hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<MerkleProofInfoDTO> {
         const localVarPath = this.basePath + '/block/{height}/receipt/{hash}/merkle'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)))
             .replace('{' + 'hash' + '}', encodeURIComponent(String(hash)));
@@ -378,7 +378,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: MerkleProofInfoDTO; }>((resolve, reject) => {
+        return new Promise<MerkleProofInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -402,7 +402,7 @@ export class BlockRoutesApi {
      * @param height The height of the block.
      * @param hash The hash of the transaction.
      */
-    public async getMerkleTransaction(height: number, hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: MerkleProofInfoDTO; }> {
+    public async getMerkleTransaction(height: number, hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<MerkleProofInfoDTO> {
         const localVarPath = this.basePath + '/block/{height}/transaction/{hash}/merkle'
             .replace('{' + 'height' + '}', encodeURIComponent(String(height)))
             .replace('{' + 'hash' + '}', encodeURIComponent(String(hash)));
@@ -442,7 +442,7 @@ export class BlockRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: MerkleProofInfoDTO; }>((resolve, reject) => {
+        return new Promise<MerkleProofInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/chainRoutesApi.ts
+++ b/src/infrastructure/api/chainRoutesApi.ts
@@ -89,7 +89,7 @@ export class ChainRoutesApi {
      * Returns the current height of the blockchain.
      * @summary Get the current height of the chain
      */
-    public async getBlockchainHeight(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: HeightInfoDTO; }> {
+    public async getBlockchainHeight(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<HeightInfoDTO> {
         const localVarPath = this.basePath + '/chain/height';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -117,7 +117,7 @@ export class ChainRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: HeightInfoDTO; }>((resolve, reject) => {
+        return new Promise<HeightInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -139,7 +139,7 @@ export class ChainRoutesApi {
      * Gets the current score of the blockchain. The higher the score, the better the chain. During synchronization, nodes try to get the best blockchain in the network.  The score for a block is derived from its difficulty and the time (in seconds) that has elapsed since the last block:      block score = difficulty − time elapsed since last block
      * @summary Get the current score of the chain
      */
-    public async getBlockchainScore(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: BlockchainScoreDTO; }> {
+    public async getBlockchainScore(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<BlockchainScoreDTO> {
         const localVarPath = this.basePath + '/chain/score';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -167,7 +167,7 @@ export class ChainRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: BlockchainScoreDTO; }>((resolve, reject) => {
+        return new Promise<BlockchainScoreDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/contractRoutesApi.ts
+++ b/src/infrastructure/api/contractRoutesApi.ts
@@ -80,7 +80,7 @@ export class ContractRoutesApi {
      * @summary Get contracts of account
      * @param publicKey The public key of the account.
      */
-    public async getAccountContract (publicKey: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }> {
+    public async getAccountContract (publicKey: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<Array<ContractInfoDTO>> {
         const localVarPath = this.basePath + '/account/{publicKey}/contracts'
             .replace('{' + 'publicKey' + '}', encodeURIComponent(String(publicKey)));
         let localVarQueryParameters: any = {};
@@ -114,7 +114,7 @@ export class ContractRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }>((resolve, reject) => {
+        return new Promise<Array<ContractInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -137,7 +137,7 @@ export class ContractRoutesApi {
      * @summary Get contracts for an array of contract\'s publicKeys
      * @param publicKeys
      */
-    public async getAccountContracts (publicKeys?: PublicKeys, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }> {
+    public async getAccountContracts (publicKeys?: PublicKeys, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<Array<ContractInfoDTO>> {
         const localVarPath = this.basePath + '/account/contracts';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -166,7 +166,7 @@ export class ContractRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }>((resolve, reject) => {
+        return new Promise<Array<ContractInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -189,7 +189,7 @@ export class ContractRoutesApi {
      * @summary Get contract by contractId
      * @param contractId The account identifier.
      */
-    public async getContract (contractId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: ContractInfoDTO;  }> {
+    public async getContract (contractId: string, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<ContractInfoDTO> {
         const localVarPath = this.basePath + '/contract/{contractId}'
             .replace('{' + 'contractId' + '}', encodeURIComponent(String(contractId)));
         let localVarQueryParameters: any = {};
@@ -223,7 +223,7 @@ export class ContractRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: ContractInfoDTO;  }>((resolve, reject) => {
+        return new Promise<ContractInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -246,7 +246,7 @@ export class ContractRoutesApi {
      * @summary Get contracts for an array of publicKeys or addresses
      * @param accountIds
      */
-    public async getContracts (accountIds: AccountIds, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }> {
+    public async getContracts (accountIds: AccountIds, options: {headers: {[name: string]: string}} = {headers: {}}) : Promise<Array<ContractInfoDTO>> {
         const localVarPath = this.basePath + '/contract';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -280,7 +280,7 @@ export class ContractRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<ContractInfoDTO>;  }>((resolve, reject) => {
+        return new Promise<Array<ContractInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/diagnosticRoutesApi.ts
+++ b/src/infrastructure/api/diagnosticRoutesApi.ts
@@ -89,7 +89,7 @@ export class DiagnosticRoutesApi {
      * Returns diagnostic information about the node storage.
      * @summary Get the storage information of the node
      */
-    public async getDiagnosticStorage(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: StorageInfoDTO; }> {
+    public async getDiagnosticStorage(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<StorageInfoDTO> {
         const localVarPath = this.basePath + '/diagnostic/storage';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -117,7 +117,7 @@ export class DiagnosticRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: StorageInfoDTO; }>((resolve, reject) => {
+        return new Promise<StorageInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -139,7 +139,7 @@ export class DiagnosticRoutesApi {
      * Returns the version of the running rest component.
      * @summary Get the version of the running rest component
      */
-    public async getServerInfo(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: ServerDTO; }> {
+    public async getServerInfo(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<ServerDTO> {
         const localVarPath = this.basePath + '/diagnostic/server';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -167,7 +167,7 @@ export class DiagnosticRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: ServerDTO; }>((resolve, reject) => {
+        return new Promise<ServerDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/metadataRoutesApi.ts
+++ b/src/infrastructure/api/metadataRoutesApi.ts
@@ -81,7 +81,7 @@ export class MetadataRoutesApi {
      * @summary Get metadata of account
      * @param accountId The account identifier.
      */
-    public async getAccountMetadata(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: AddressMetadataInfoDTO; }> {
+    public async getAccountMetadata(accountId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<AddressMetadataInfoDTO> {
         const localVarPath = this.basePath + '/account/{accountId}/metadata'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
         let localVarQueryParameters: any = {};
@@ -115,7 +115,7 @@ export class MetadataRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AddressMetadataInfoDTO; }>((resolve, reject) => {
+        return new Promise<AddressMetadataInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -138,7 +138,7 @@ export class MetadataRoutesApi {
      * @summary Get metadata of namespace/mosaic/account
      * @param metadataId The metadata identifier.
      */
-    public async getMetadata(metadataId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NamespaceMetadataInfoDTO; }> {
+    public async getMetadata(metadataId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NamespaceMetadataInfoDTO> {
         const localVarPath = this.basePath + '/metadata/{metadataId}'
             .replace('{' + 'metadataId' + '}', encodeURIComponent(String(metadataId)));
         let localVarQueryParameters: any = {};
@@ -172,7 +172,7 @@ export class MetadataRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NamespaceMetadataInfoDTO; }>((resolve, reject) => {
+        return new Promise<NamespaceMetadataInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -195,7 +195,7 @@ export class MetadataRoutesApi {
      * @summary Get metadatas(namespace/mosaic/account) for an array of metadataids
      * @param metadataIds
      */
-    public async getMetadatas(metadataIds?: MetadataIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<AddressMetadataInfoDTO>; }> {
+    public async getMetadatas(metadataIds?: MetadataIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<AddressMetadataInfoDTO>> {
         const localVarPath = this.basePath + '/metadata';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -224,7 +224,7 @@ export class MetadataRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<AddressMetadataInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<AddressMetadataInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -247,7 +247,7 @@ export class MetadataRoutesApi {
      * @summary Get metadata of mosaic
      * @param mosaicId The mosaic identifier.
      */
-    public async getMosaicMetadata(mosaicId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: MosaicMetadataInfoDTO; }> {
+    public async getMosaicMetadata(mosaicId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<MosaicMetadataInfoDTO> {
         const localVarPath = this.basePath + '/mosaic/{mosaicId}/metadata'
             .replace('{' + 'mosaicId' + '}', encodeURIComponent(String(mosaicId)));
         let localVarQueryParameters: any = {};
@@ -281,7 +281,7 @@ export class MetadataRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: MosaicMetadataInfoDTO; }>((resolve, reject) => {
+        return new Promise<MosaicMetadataInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -304,7 +304,7 @@ export class MetadataRoutesApi {
      * @summary Get metadata of namespace
      * @param namespaceId The namespace identifier.
      */
-    public async getNamespaceMetadata(namespaceId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NamespaceMetadataInfoDTO; }> {
+    public async getNamespaceMetadata(namespaceId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NamespaceMetadataInfoDTO> {
         const localVarPath = this.basePath + '/namespace/{namespaceId}/metadata'
             .replace('{' + 'namespaceId' + '}', encodeURIComponent(String(namespaceId)));
         let localVarQueryParameters: any = {};
@@ -338,7 +338,7 @@ export class MetadataRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NamespaceMetadataInfoDTO; }>((resolve, reject) => {
+        return new Promise<NamespaceMetadataInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/mosaicRoutesApi.ts
+++ b/src/infrastructure/api/mosaicRoutesApi.ts
@@ -91,7 +91,7 @@ export class MosaicRoutesApi {
      * @summary Get mosaic information
      * @param mosaicId The mosaic identifier.
      */
-    public async getMosaic(mosaicId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: MosaicInfoDTO; }> {
+    public async getMosaic(mosaicId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<MosaicInfoDTO> {
         const localVarPath = this.basePath + '/mosaic/{mosaicId}'
             .replace('{' + 'mosaicId' + '}', encodeURIComponent(String(mosaicId)));
         let localVarQueryParameters: any = {};
@@ -125,7 +125,7 @@ export class MosaicRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: MosaicInfoDTO; }>((resolve, reject) => {
+        return new Promise<MosaicInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -148,7 +148,7 @@ export class MosaicRoutesApi {
      * @summary Get mosaics information for an array of mosaics
      * @param mosaicIds
      */
-    public async getMosaics(mosaicIds: MosaicIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<MosaicInfoDTO>; }> {
+    public async getMosaics(mosaicIds: MosaicIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<MosaicInfoDTO>> {
         const localVarPath = this.basePath + '/mosaic';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -182,7 +182,7 @@ export class MosaicRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<MosaicInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<MosaicInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -205,7 +205,7 @@ export class MosaicRoutesApi {
      * @summary Get readable names for a set of mosaics
      * @param mosaicIds
      */
-    public async getMosaicsNames(mosaicIds: MosaicIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<MosaicNamesDTO>; }> {
+    public async getMosaicsNames(mosaicIds: MosaicIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<MosaicNamesDTO>> {
         const localVarPath = this.basePath + '/mosaic/names';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -239,7 +239,7 @@ export class MosaicRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<MosaicNamesDTO>; }>((resolve, reject) => {
+        return new Promise<Array<MosaicNamesDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/namespaceRoutesApi.ts
+++ b/src/infrastructure/api/namespaceRoutesApi.ts
@@ -92,7 +92,7 @@ export class NamespaceRoutesApi {
      * @summary Get namespace information
      * @param namespaceId The namespace identifier.
      */
-    public async getNamespace(namespaceId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NamespaceInfoDTO; }> {
+    public async getNamespace(namespaceId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NamespaceInfoDTO> {
         const localVarPath = this.basePath + '/namespace/{namespaceId}'
             .replace('{' + 'namespaceId' + '}', encodeURIComponent(String(namespaceId)));
         let localVarQueryParameters: any = {};
@@ -126,7 +126,7 @@ export class NamespaceRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NamespaceInfoDTO; }>((resolve, reject) => {
+        return new Promise<NamespaceInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -151,7 +151,7 @@ export class NamespaceRoutesApi {
      * @param pageSize The number of namespaces to return.
      * @param id The namespace id up to which namespace objects are returned.
      */
-    public async getNamespacesFromAccount(accountId: string, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<NamespaceInfoDTO>; }> {
+    public async getNamespacesFromAccount(accountId: string, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<NamespaceInfoDTO>> {
         const localVarPath = this.basePath + '/account/{accountId}/namespaces'
             .replace('{' + 'accountId' + '}', encodeURIComponent(String(accountId)));
         let localVarQueryParameters: any = {};
@@ -193,7 +193,7 @@ export class NamespaceRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<NamespaceInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<NamespaceInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -218,7 +218,7 @@ export class NamespaceRoutesApi {
      * @param pageSize The number of namespaces to return.
      * @param id The namespace id up to which namespace objects are returned.
      */
-    public async getNamespacesFromAccounts(accountIds: AccountIds, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<NamespaceInfoDTO>; }> {
+    public async getNamespacesFromAccounts(accountIds: AccountIds, pageSize?: number, id?: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<NamespaceInfoDTO>> {
         const localVarPath = this.basePath + '/account/namespaces';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -260,7 +260,7 @@ export class NamespaceRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<NamespaceInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<NamespaceInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -283,7 +283,7 @@ export class NamespaceRoutesApi {
      * @summary Get readable names for a set of namespaces
      * @param namespaceIds
      */
-    public async getNamespacesNames(namespaceIds: NamespaceIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<NamespaceNameDTO>; }> {
+    public async getNamespacesNames(namespaceIds: NamespaceIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<NamespaceNameDTO>> {
         const localVarPath = this.basePath + '/namespace/names';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -317,7 +317,7 @@ export class NamespaceRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<NamespaceNameDTO>; }>((resolve, reject) => {
+        return new Promise<Array<NamespaceNameDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/networkRoutesApi.ts
+++ b/src/infrastructure/api/networkRoutesApi.ts
@@ -88,7 +88,7 @@ export class NetworkRoutesApi {
      * Returns the current network type.
      * @summary Get the current network type of the chain
      */
-    public async getNetworkType(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NetworkTypeDTO; }> {
+    public async getNetworkType(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NetworkTypeDTO> {
         const localVarPath = this.basePath + '/network';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -116,7 +116,7 @@ export class NetworkRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NetworkTypeDTO; }>((resolve, reject) => {
+        return new Promise<NetworkTypeDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/nodeRoutesApi.ts
+++ b/src/infrastructure/api/nodeRoutesApi.ts
@@ -89,7 +89,7 @@ export class NodeRoutesApi {
      * Supplies additional information about the application running on a node.
      * @summary Get the node information
      */
-    public async getNodeInfo(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NodeInfoDTO; }> {
+    public async getNodeInfo(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NodeInfoDTO> {
         const localVarPath = this.basePath + '/node/info';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -117,7 +117,7 @@ export class NodeRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NodeInfoDTO; }>((resolve, reject) => {
+        return new Promise<NodeInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -139,7 +139,7 @@ export class NodeRoutesApi {
      * Gets the node time at the moment the reply was sent and received.
      * @summary Get the node time
      */
-    public async getNodeTime(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: NodeTimeDTO; }> {
+    public async getNodeTime(options: { headers: { [name: string]: string } } = { headers: {} }): Promise<NodeTimeDTO> {
         const localVarPath = this.basePath + '/node/time';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -167,7 +167,7 @@ export class NodeRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: NodeTimeDTO; }>((resolve, reject) => {
+        return new Promise<NodeTimeDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/api/transactionRoutesApi.ts
+++ b/src/infrastructure/api/transactionRoutesApi.ts
@@ -95,7 +95,7 @@ export class TransactionRoutesApi {
      * @summary Announce a cosignature transaction
      * @param cosignature
      */
-    public async announceCosignatureTransaction(cosignature: Cosignature, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }> {
+    public async announceCosignatureTransaction(cosignature: Cosignature, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<AnnounceTransactionInfoDTO> {
         const localVarPath = this.basePath + '/transaction/cosignature';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -129,7 +129,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }>((resolve, reject) => {
+        return new Promise<AnnounceTransactionInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -152,7 +152,7 @@ export class TransactionRoutesApi {
      * @summary Announce an aggregate bonded transaction
      * @param transactionPayload
      */
-    public async announcePartialTransaction(transactionPayload: TransactionPayload, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }> {
+    public async announcePartialTransaction(transactionPayload: TransactionPayload, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<AnnounceTransactionInfoDTO> {
         const localVarPath = this.basePath + '/transaction/partial';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -186,7 +186,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }>((resolve, reject) => {
+        return new Promise<AnnounceTransactionInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -209,7 +209,7 @@ export class TransactionRoutesApi {
      * @summary Announce a new transaction
      * @param transactionPayload
      */
-    public async announceTransaction(transactionPayload: TransactionPayload, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }> {
+    public async announceTransaction(transactionPayload: TransactionPayload, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<AnnounceTransactionInfoDTO> {
         const localVarPath = this.basePath + '/transaction';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -243,7 +243,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: AnnounceTransactionInfoDTO; }>((resolve, reject) => {
+        return new Promise<AnnounceTransactionInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -266,7 +266,7 @@ export class TransactionRoutesApi {
      * @summary Get transaction information
      * @param transactionId The transaction id or hash.
      */
-    public async getTransaction(transactionId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: TransactionInfoDTO; }> {
+    public async getTransaction(transactionId: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<TransactionInfoDTO> {
         const localVarPath = this.basePath + '/transaction/{transactionId}'
             .replace('{' + 'transactionId' + '}', encodeURIComponent(String(transactionId)));
         let localVarQueryParameters: any = {};
@@ -300,7 +300,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: TransactionInfoDTO; }>((resolve, reject) => {
+        return new Promise<TransactionInfoDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -323,7 +323,7 @@ export class TransactionRoutesApi {
      * @summary Get transaction status
      * @param hash The transaction hash.
      */
-    public async getTransactionStatus(hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: TransactionStatusDTO; }> {
+    public async getTransactionStatus(hash: string, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<TransactionStatusDTO> {
         const localVarPath = this.basePath + '/transaction/{hash}/status'
             .replace('{' + 'hash' + '}', encodeURIComponent(String(hash)));
         let localVarQueryParameters: any = {};
@@ -357,7 +357,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: TransactionStatusDTO; }>((resolve, reject) => {
+        return new Promise<TransactionStatusDTO>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -380,7 +380,7 @@ export class TransactionRoutesApi {
      * @summary Get transactions information
      * @param transactionIds
      */
-    public async getTransactions(transactionIds: TransactionIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }> {
+    public async getTransactions(transactionIds: TransactionIds, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionInfoDTO>> {
         const localVarPath = this.basePath + '/transaction';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -414,7 +414,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionInfoDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionInfoDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);
@@ -437,7 +437,7 @@ export class TransactionRoutesApi {
      * @summary Get transactions status.
      * @param transactionHashes
      */
-    public async getTransactionsStatuses(transactionHashes: TransactionHashes, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<{ response: http.ClientResponse; body: Array<TransactionStatusDTO>; }> {
+    public async getTransactionsStatuses(transactionHashes: TransactionHashes, options: { headers: { [name: string]: string } } = { headers: {} }): Promise<Array<TransactionStatusDTO>> {
         const localVarPath = this.basePath + '/transaction/statuses';
         let localVarQueryParameters: any = {};
         let localVarHeaderParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -471,7 +471,7 @@ export class TransactionRoutesApi {
                 localVarRequestOptions.form = localVarFormParams;
             }
         }
-        return new Promise<{ response: http.ClientResponse; body: Array<TransactionStatusDTO>; }>((resolve, reject) => {
+        return new Promise<Array<TransactionStatusDTO>>((resolve, reject) => {
             localVarRequest(localVarRequestOptions, (error, response, body) => {
                 if (error) {
                     reject(error);

--- a/src/infrastructure/builders/AggregateTransaction.ts
+++ b/src/infrastructure/builders/AggregateTransaction.ts
@@ -56,7 +56,7 @@ export class AggregateTransaction extends VerifiableTransaction {
         return signedTransaction;
     }
 
-    signTransactionGivenSignatures(initializer, cosignedSignedTransactions, generationHash, signSchema) {
+    signTransactionGivenSignatures(initializer, cosignedSignedTransactions, generationHash, signSchema = SignSchema.SHA3) {
         const signedTransaction = this.signTransaction(initializer, generationHash, signSchema);
         cosignedSignedTransactions.forEach((cosignedTransaction) => {
             signedTransaction.payload = signedTransaction.payload + cosignedTransaction.signer + cosignedTransaction.signature;

--- a/src/model/transaction/CosignatureTransaction.ts
+++ b/src/model/transaction/CosignatureTransaction.ts
@@ -53,14 +53,14 @@ export class CosignatureTransaction {
      * Creating a new CosignatureSignedTransaction
      * @param account - The signing account
      * @param payload - off transaction payload (aggregated transaction is unannounced)
-     * @param gernationHash - Network generation hash
+     * @param generationHash - Network generation hash
      * @returns {CosignatureSignedTransaction}
      */
-    public static signTransactionPayload(account: Account, payload: string, gernationHash: string, signSchema = SignSchema.SHA3): CosignatureSignedTransaction {
+    public static signTransactionPayload(account: Account, payload: string, generationHash: string, signSchema = SignSchema.SHA3): CosignatureSignedTransaction {
         /**
          * For aggregated complete transaction, cosignatories are gathered off chain announced.
          */
-        const transactionHash = VerifiableTransaction.createTransactionHash(payload, Array.from(Convert.hexToUint8(gernationHash)));
+        const transactionHash = VerifiableTransaction.createTransactionHash(payload, Array.from(Convert.hexToUint8(generationHash)));
         const aggregateSignatureTransaction = new CosignaturetransactionLibrary(transactionHash);
         const signedTransactionRaw = aggregateSignatureTransaction.signCosignatoriesTransaction(account, signSchema);
         return new CosignatureSignedTransaction(signedTransactionRaw.parentHash,

--- a/src/model/transaction/CosignatureTransaction.ts
+++ b/src/model/transaction/CosignatureTransaction.ts
@@ -20,6 +20,7 @@ import {Account} from '../account/Account';
 import {AggregateTransaction} from './AggregateTransaction';
 import {CosignatureSignedTransaction} from './CosignatureSignedTransaction';
 import { VerifiableTransaction } from '../../infrastructure/builders/VerifiableTransaction';
+import { Convert } from '../../core/format';
 
 /**
  * Cosignature transaction is used to sign an aggregate transactions with missing cosignatures.
@@ -55,13 +56,13 @@ export class CosignatureTransaction {
      * @param gernationHash - Network generation hash
      * @returns {CosignatureSignedTransaction}
      */
-    public static signTransactionPayload(account: Account, payload: string, gernationHash: string): CosignatureSignedTransaction {
+    public static signTransactionPayload(account: Account, payload: string, gernationHash: string, signSchema = SignSchema.SHA3): CosignatureSignedTransaction {
         /**
          * For aggregated complete transaction, cosignatories are gathered off chain announced.
          */
-        const transactionHash = VerifiableTransaction.createTransactionHash(payload, gernationHash);
+        const transactionHash = VerifiableTransaction.createTransactionHash(payload, Array.from(Convert.hexToUint8(gernationHash)));
         const aggregateSignatureTransaction = new CosignaturetransactionLibrary(transactionHash);
-        const signedTransactionRaw = aggregateSignatureTransaction.signCosignatoriesTransaction(account);
+        const signedTransactionRaw = aggregateSignatureTransaction.signCosignatoriesTransaction(account, signSchema);
         return new CosignatureSignedTransaction(signedTransactionRaw.parentHash,
             signedTransactionRaw.signature,
             signedTransactionRaw.signer);

--- a/test/infrastructure/Listener.spec.ts
+++ b/test/infrastructure/Listener.spec.ts
@@ -34,7 +34,7 @@ describe('Listener', () => {
 
     describe('onerror', () => {
         it('should reject because of wrong server url', async () => {
-            const listener = new Listener('https://notcorrecturl:0000');
+            const listener = new Listener('https://notcorrecturl:0');
             await listener.open()
                 .then((result) => {
                     listener.close();
@@ -42,7 +42,7 @@ describe('Listener', () => {
                 })
                 .catch((error) => {
                     listener.close();
-                    expect(error.message.toString()).to.be.equal("getaddrinfo ENOTFOUND notcorrecturl notcorrecturl:0000");
+                    expect(error.message.toString()).to.be.equal("getaddrinfo ENOTFOUND notcorrecturl notcorrecturl:0");
                 });
         });
     });


### PR DESCRIPTION
- npm dependencies has been updated to their latest versions to solve the complaints during npm install to fix #24 
- due to breaking changes with new version of instanbul/nyc, the coverage reporting has been changed to run over ts code directly (not over generated js as it was before)
- some types in generated api had to be added/fixed to make it compilable again
- AggregateComplete cosign with signatures fixed to solve #25  