### PR TITLE
- fix circular import issue #39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tsjs-xpx-chain-sdk",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsjs-xpx-chain-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Proximax Blockchain sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",

--- a/src/infrastructure/builders/MosaicCreationTransaction.ts
+++ b/src/infrastructure/builders/MosaicCreationTransaction.ts
@@ -26,7 +26,7 @@ import {
 import { VerifiableTransaction } from './VerifiableTransaction';
 
 import {flatbuffers} from 'flatbuffers';
-import { MosaicPropertyType } from '../../model/model';
+import { MosaicPropertyType } from '../../model/mosaic/MosaicPropertyType';
 
 const {
     MosaicDefinitionTransactionBuffer,

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -30,10 +30,11 @@ import {AddressAliasTransaction} from '../../model/transaction/AddressAliasTrans
 import {AggregateTransaction} from '../../model/transaction/AggregateTransaction';
 import {AggregateTransactionCosignature} from '../../model/transaction/AggregateTransactionCosignature';
 import {AggregateTransactionInfo} from '../../model/transaction/AggregateTransactionInfo';
+import {ChainConfigTransaction} from '../../model/transaction/ChainConfigTransaction';
+import {ChainUpgradeTransaction} from '../../model/transaction/ChainUpgradeTransaction';
 import {Deadline} from '../../model/transaction/Deadline';
 import { EncryptedMessage } from '../../model/transaction/EncryptedMessage';
 import {LockFundsTransaction} from '../../model/transaction/LockFundsTransaction';
-import { MessageType } from '../../model/transaction/MessageType';
 import {AccountAddressRestrictionModificationTransaction} from '../../model/transaction/AccountAddressRestrictionModificationTransaction';
 import {AccountOperationRestrictionModificationTransaction} from '../../model/transaction/AccountOperationRestrictionModificationTransaction';
 import {AccountMosaicRestrictionModificationTransaction} from '../../model/transaction/AccountMosaicRestrictionModificationTransaction';
@@ -55,7 +56,6 @@ import {UInt64} from '../../model/UInt64';
 import { ModifyMetadataTransaction, MetadataModification } from '../../model/transaction/ModifyMetadataTransaction';
 import { MetadataType } from '../../model/metadata/MetadataType';
 import { ModifyContractTransaction } from '../../model/transaction/ModifyContractTransaction';
-import { ChainConfigTransaction, ChainUpgradeTransaction } from '../../model/model';
 
 /**
  * @internal


### PR DESCRIPTION
Users reported they are unable to import MosaicDefinitionTransaction the default way. This change should fix it.