### PR TITLE
- add missing support for {address}/transactions/incoming api route #41

### DIFF
--- a/e2e/infrastructure/AccountHttp.spec.ts
+++ b/e2e/infrastructure/AccountHttp.spec.ts
@@ -104,9 +104,18 @@ describe('AccountHttp', () => {
         });
     });
 
-    describe('incomingTransactions', () => {
+    describe('incomingTransactions using public key', () => {
         it('should call incomingTransactions successfully', (done) => {
             accountHttp.incomingTransactions(TestingAccount.publicAccount).subscribe((transactions) => {
+                expect(transactions.length).to.be.greaterThan(0);
+                done();
+            });
+        });
+    });
+
+    describe('incomingTransactions using address', () => {
+        it('should call incomingTransactions successfully', (done) => {
+            accountHttp.incomingTransactions(TestingAccount.address).subscribe((transactions) => {
                 expect(transactions.length).to.be.greaterThan(0);
                 done();
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsjs-xpx-chain-sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Proximax Blockchain sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",

--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -234,13 +234,14 @@ export class AccountHttp extends Http implements AccountRepository {
     /**
      * Gets an array of transactions for which an account is the recipient of a transaction.
      * A transaction is said to be incoming with respect to an account if the account is the recipient of a transaction.
-     * @param publicAccount - User public account
+     * @param accountId - User public account or address (you can use address if public account is not known to the network just yet)
      * @param queryParams - (Optional) Query params
      * @returns Observable<Transaction[]>
      */
-    public incomingTransactions(publicAccount: PublicAccount, queryParams?: QueryParams): Observable <Transaction[]> {
+    public incomingTransactions(accountId: PublicAccount | Address, queryParams?: QueryParams): Observable <Transaction[]> {
+        const id = accountId instanceof PublicAccount ? (accountId as PublicAccount).publicKey : (accountId as Address).plain();
         return observableFrom(
-            this.accountRoutesApi.incomingTransactions(publicAccount.publicKey,
+            this.accountRoutesApi.incomingTransactions(id,
                                                        this.queryParams(queryParams).pageSize,
                                                        this.queryParams(queryParams).id,
                                                        this.queryParams(queryParams).order)).pipe(


### PR DESCRIPTION
There is now no way in the sdk how to get transactions for an account without pk announced to the network. API provides {address}/transactions/incoming for that at least.