### PR TITLE
Issue/56

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - "8"
-  - "9"
   - "10"
+  - "12"
 cache:
   directories:
     - "node_modules"

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -578,7 +578,7 @@ describe('TransactionHttp', () => {
             );
             const signedTransaction = TestingAccount.sign(aggregateTransaction, factory.generationHash);
             const hashLockTransaction = HashLockTransaction.create(Deadline.create(),
-                new Mosaic(new NamespaceId('cat.currency'), UInt64.fromUint(10 * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY))),
+                new Mosaic(new NamespaceId('prx.xpx'), UInt64.fromUint(10 * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY))),
                 UInt64.fromUint(10000),
                 signedTransaction,
                 ConfNetworkType);

--- a/src/core/format/RawAddress.ts
+++ b/src/core/format/RawAddress.ts
@@ -85,7 +85,7 @@ export class RawAddress {
         const publicKeyHash = signSchema === SignSchema.SHA3 ? sha3_256.arrayBuffer(publicKey) : keccak256.arrayBuffer(publicKey);
 
         // step 2: ripemd160 hash of (1)
-        const ripemdHash = new RIPEMD160().update(new Buffer(publicKeyHash)).digest();
+        const ripemdHash = new RIPEMD160().update(Buffer.from(publicKeyHash)).digest();
 
         // step 3: add network identifier byte in front of (2)
         const decodedAddress = new Uint8Array(RawAddress.constants.sizes.addressDecoded);

--- a/src/model/mosaic/NetworkCurrencyMosaic.ts
+++ b/src/model/mosaic/NetworkCurrencyMosaic.ts
@@ -13,59 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import {NamespaceId} from '../namespace/NamespaceId';
 import {UInt64} from '../UInt64';
-import {Mosaic} from './Mosaic';
+import { NetworkMosaic, XpxMosaicProperties, KnownMosaicProperties } from './NetworkMosaic';
 
 /**
  * NetworkCurrencyMosaic mosaic
  *
  * This represents the per-network currency mosaic. This mosaicId is aliased
- * with namespace name `prx.xpx`.
+ * with namespace name `prx.xpx` from XpxMosaicProperties definition by default.
  *
  * @since 0.10.2
  */
-export class NetworkCurrencyMosaic extends Mosaic {
-
-    /**
-     * namespaceId of `currency` namespace.
-     *
-     * @type {Id}
-     */
-    public static NAMESPACE_ID = new NamespaceId('prx.xpx');
-
-    /**
-     * Divisiblity
-     * @type {number}
-     */
-    public static DIVISIBILITY = 6;
-
-    /**
-     * Initial supply
-     * @type {number}
-     */
-    public static INITIAL_SUPPLY = 9000000000;
-
-    /**
-     * Is tranferable
-     * @type {boolean}
-     */
-    public static TRANSFERABLE = true;
-
-    /**
-     * Is Supply mutable
-     * @type {boolean}
-     */
-    public static SUPPLY_MUTABLE = false;
-
+export class NetworkCurrencyMosaic extends NetworkMosaic {
     /**
      * constructor
      * @param owner
      * @param amount
      */
-    private constructor(amount: UInt64) {
-        super(NetworkCurrencyMosaic.NAMESPACE_ID, amount);
+    private constructor(amount: UInt64, networkMosaicProperties: KnownMosaicProperties) {
+        super(amount, networkMosaicProperties);
     }
 
     /**
@@ -74,11 +40,8 @@ export class NetworkCurrencyMosaic extends Mosaic {
      * @param amount
      * @returns {NetworkCurrencyMosaic}
      */
-    public static createRelative(amount: UInt64 | number) {
-        if (typeof amount === 'number') {
-            return new NetworkCurrencyMosaic(UInt64.fromUint(amount * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY)));
-        }
-        return new NetworkCurrencyMosaic(UInt64.fromUint((amount as UInt64).compact() * Math.pow(10, NetworkCurrencyMosaic.DIVISIBILITY)));
+    public static createRelative(amount: UInt64 | number, networkMosaicProperties = XpxMosaicProperties) {
+        return new NetworkCurrencyMosaic(NetworkMosaic.createRelativeAmount(amount, networkMosaicProperties.MOSAIC_PROPERTIES.divisibility), networkMosaicProperties);
     }
 
     /**
@@ -88,10 +51,7 @@ export class NetworkCurrencyMosaic extends Mosaic {
      * @param amount
      * @returns {NetworkCurrencyMosaic}
      */
-    public static createAbsolute(amount: UInt64 | number) {
-        if (typeof amount === 'number') {
-            return new NetworkCurrencyMosaic(UInt64.fromUint(amount));
-        }
-        return new NetworkCurrencyMosaic(amount as UInt64);
+    public static createAbsolute(amount: UInt64 | number, networkMosaicProperties = XpxMosaicProperties) {
+        return new NetworkCurrencyMosaic(NetworkMosaic.createAbsoluteAmount(amount), networkMosaicProperties);
     }
 }

--- a/src/model/mosaic/NetworkCurrencyMosaic.ts
+++ b/src/model/mosaic/NetworkCurrencyMosaic.ts
@@ -17,14 +17,13 @@
 import {NamespaceId} from '../namespace/NamespaceId';
 import {UInt64} from '../UInt64';
 import {Mosaic} from './Mosaic';
-import {MosaicId} from './MosaicId';
 
 /**
  * NetworkCurrencyMosaic mosaic
- * 
+ *
  * This represents the per-network currency mosaic. This mosaicId is aliased
- * with namespace name `cat.currency`.
- * 
+ * with namespace name `prx.xpx`.
+ *
  * @since 0.10.2
  */
 export class NetworkCurrencyMosaic extends Mosaic {
@@ -34,7 +33,7 @@ export class NetworkCurrencyMosaic extends Mosaic {
      *
      * @type {Id}
      */
-    public static NAMESPACE_ID = new NamespaceId('cat.currency');
+    public static NAMESPACE_ID = new NamespaceId('prx.xpx');
 
     /**
      * Divisiblity
@@ -46,7 +45,7 @@ export class NetworkCurrencyMosaic extends Mosaic {
      * Initial supply
      * @type {number}
      */
-    public static INITIAL_SUPPLY = 8999999998;
+    public static INITIAL_SUPPLY = 9000000000;
 
     /**
      * Is tranferable

--- a/src/model/mosaic/NetworkHarvestMosaic.ts
+++ b/src/model/mosaic/NetworkHarvestMosaic.ts
@@ -13,59 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {NamespaceId} from '../namespace/NamespaceId';
 import {UInt64} from '../UInt64';
-import {Mosaic} from './Mosaic';
-import {MosaicId} from './MosaicId';
+import { NetworkMosaic, KnownMosaicProperties, XpxMosaicProperties } from './NetworkMosaic';
 
 /**
  * NetworkHarvestMosaic mosaic
  *
  * This represents the per-network harvest mosaic. This mosaicId is aliased
- * with namespace name `cat.harvest`.
+ * with namespace name `prx.xpx` from XpxMosaicProperties definition by default.
  *
  * @since 0.10.2
  */
-export class NetworkHarvestMosaic extends Mosaic {
-
-    /**
-     * namespaceId of `currency` namespace.
-     *
-     * @type {Id}
-     */
-    public static NAMESPACE_ID = new NamespaceId('cat.harvest');
-
-    /**
-     * Divisiblity
-     * @type {number}
-     */
-    public static DIVISIBILITY = 3;
-
-    /**
-     * Initial supply
-     * @type {number}
-     */
-    public static INITIAL_SUPPLY = 15000000;
-
-    /**
-     * Is tranferable
-     * @type {boolean}
-     */
-    public static TRANSFERABLE = true;
-
-    /**
-     * Is Supply mutable
-     * @type {boolean}
-     */
-    public static SUPPLY_MUTABLE = true;
-
+export class NetworkHarvestMosaic extends NetworkMosaic {
     /**
      * constructor
      * @param owner
      * @param amount
      */
-    private constructor(amount: UInt64) {
-        super(NetworkHarvestMosaic.NAMESPACE_ID, amount);
+    private constructor(amount: UInt64, networkMosaicProperties: KnownMosaicProperties) {
+        super(amount, networkMosaicProperties);
     }
 
     /**
@@ -74,11 +40,8 @@ export class NetworkHarvestMosaic extends Mosaic {
      * @param amount
      * @returns {NetworkHarvestMosaic}
      */
-    public static createRelative(amount: UInt64 | number) {
-        if (typeof amount === 'number') {
-            return new NetworkHarvestMosaic(UInt64.fromUint(amount * Math.pow(10, NetworkHarvestMosaic.DIVISIBILITY)));
-        }
-        return new NetworkHarvestMosaic(UInt64.fromUint((amount as UInt64).compact() * Math.pow(10, NetworkHarvestMosaic.DIVISIBILITY)));
+    public static createRelative(amount: UInt64 | number, networkMosaicProperties = XpxMosaicProperties) {
+        return new NetworkHarvestMosaic(NetworkMosaic.createRelativeAmount(amount, networkMosaicProperties.MOSAIC_PROPERTIES.divisibility), networkMosaicProperties);
     }
 
     /**
@@ -88,10 +51,7 @@ export class NetworkHarvestMosaic extends Mosaic {
      * @param amount
      * @returns {NetworkHarvestMosaic}
      */
-    public static createAbsolute(amount: UInt64 | number) {
-        if (typeof amount === 'number') {
-            return new NetworkHarvestMosaic(UInt64.fromUint(amount));
-        }
-        return new NetworkHarvestMosaic(amount as UInt64);
+    public static createAbsolute(amount: UInt64 | number, networkMosaicProperties = XpxMosaicProperties) {
+        return new NetworkHarvestMosaic(NetworkMosaic.createAbsoluteAmount(amount), networkMosaicProperties);
     }
 }

--- a/src/model/mosaic/NetworkMosaic.ts
+++ b/src/model/mosaic/NetworkMosaic.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {NamespaceId} from '../namespace/NamespaceId';
+import {UInt64} from '../UInt64';
+import {Mosaic} from './Mosaic';
+import { MosaicId } from './MosaicId';
+import { MosaicProperties } from './MosaicProperties';
+
+export class KnownMosaicProperties {
+    constructor(
+        public readonly ID: NamespaceId | MosaicId,
+        public readonly INITIAL_SUPPLY: UInt64,
+        public readonly MOSAIC_PROPERTIES: MosaicProperties
+    ) {
+
+    }
+}
+
+export const XpxMosaicProperties = new KnownMosaicProperties(
+    new NamespaceId('prx.xpx'),
+    UInt64.fromUint(9000000000), // initial supply
+    MosaicProperties.create({
+        supplyMutable: false,
+        transferable: true,
+        divisibility: 6
+    })
+);
+
+/**
+ * NetworkMosaic mosaic
+ *
+ * This represents the per-network mosaic. This mosaicId is aliased
+ * with namespace name `prx.xpx` by default.
+ *
+ */
+export class NetworkMosaic extends Mosaic {
+    private _networkMosaicProperties: KnownMosaicProperties;
+
+    protected constructor(amount: UInt64, networkMosaicProperties: KnownMosaicProperties) {
+        super(networkMosaicProperties.ID, amount);
+        this._networkMosaicProperties = networkMosaicProperties;
+    }
+
+    public get ID() {
+        return this.id;
+    }
+
+    public get DIVISIBILITY() {
+        return this._networkMosaicProperties.MOSAIC_PROPERTIES.divisibility;
+    }
+
+    public get INITIAL_SUPPLY() {
+        return this._networkMosaicProperties.INITIAL_SUPPLY;
+    }
+
+    public get TRANSFERABLE() {
+        return this._networkMosaicProperties.MOSAIC_PROPERTIES.transferable;
+    }
+
+    public get SUPPLY_MUTABLE() {
+        return this._networkMosaicProperties.MOSAIC_PROPERTIES.supplyMutable;
+    }
+
+    public static createRelativeAmount(amount: UInt64 | number, divisibility: number) {
+        if (typeof amount === 'number') {
+            return UInt64.fromUint(amount * Math.pow(10, divisibility));
+        }
+        return UInt64.fromUint((amount as UInt64).compact() * Math.pow(10, divisibility));
+    }
+
+    public static createAbsoluteAmount(amount: UInt64 | number) {
+        if (typeof amount === 'number') {
+            return UInt64.fromUint(amount);
+        }
+        return amount as UInt64;
+    }
+}

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -60,6 +60,7 @@ import { TransactionType } from '../../../src/model/transaction/TransactionType'
 import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
 import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount } from '../../conf/conf.spec';
+import { XpxMosaicProperties } from '../../../src/model/mosaic/NetworkMosaic';
 
 describe('TransactionMapping - createFromPayload', () => {
     let account: Account;
@@ -472,7 +473,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
         const transaction = TransactionMapping.createFromPayload(signedLockFundTransaction.payload) as LockFundsTransaction;
 
-        deepEqual(transaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(transaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(transaction.mosaic.amount.compact()).to.be.equal(10000000);
         expect(transaction.hash).to.be.equal(signedTransaction.hash);
     });

--- a/test/infrastructure/Listener.spec.ts
+++ b/test/infrastructure/Listener.spec.ts
@@ -42,7 +42,7 @@ describe('Listener', () => {
                 })
                 .catch((error) => {
                     listener.close();
-                    expect(error.message.toString()).to.be.equal("getaddrinfo ENOTFOUND notcorrecturl notcorrecturl:0");
+                    expect(error.message.toString()).to.contain("getaddrinfo ENOTFOUND notcorrecturl");
                 });
         });
     });

--- a/test/model/mosaic/MosaicNonce.spec.ts
+++ b/test/model/mosaic/MosaicNonce.spec.ts
@@ -22,9 +22,9 @@ import {MosaicNonce} from '../../../src/model/mosaic/MosaicNonce';
 describe('MosaicNonce', () => {
 
     it('should be created from Uint8Array', () => {
-        const nonce = new MosaicNonce(new Uint8Array([0x0, 0x0, 0x0, 0x0]));
-        deepEqual(nonce.nonce, new Uint8Array([0x0, 0x0, 0x0, 0x0]));
-        deepEqual(nonce.toDTO(), [0, 0, 0, 0]);
+        const nonce = new MosaicNonce(new Uint8Array([0x12, 0x34, 0x56, 0x78]));
+        deepEqual(nonce.nonce, new Uint8Array([0x12, 0x34, 0x56, 0x78]));
+        deepEqual(nonce.toDTO(), new Uint8Array([0x12, 0x34, 0x56, 0x78]));
     });
 
     it('should create random nonce', () => {
@@ -41,8 +41,8 @@ describe('MosaicNonce', () => {
     });
 
     it('should create nonce from hexadecimal notation', () => {
-        const nonce = MosaicNonce.createFromHex('00000000');
+        const nonce = MosaicNonce.createFromHex('12345678');
         expect(nonce.nonce).to.not.be.null;
-        deepEqual(nonce.nonce, new Uint8Array([0x0, 0x0, 0x0, 0x0]));
+        deepEqual(nonce.nonce, new Uint8Array([0x12, 0x34, 0x56, 0x78]));
     });
 });

--- a/test/model/mosaic/NetworkCurrencyMosaic.spec.ts
+++ b/test/model/mosaic/NetworkCurrencyMosaic.spec.ts
@@ -16,7 +16,6 @@
 
 import {deepEqual} from 'assert';
 import {expect} from 'chai';
-import {MosaicId} from '../../../src/model/mosaic/MosaicId';
 import {NetworkCurrencyMosaic} from '../../../src/model/mosaic/NetworkCurrencyMosaic';
 import {NamespaceId} from '../../../src/model/namespace/NamespaceId';
 
@@ -26,7 +25,7 @@ describe('NetworkCurrencyMosaic', () => {
 
         const currency = NetworkCurrencyMosaic.createRelative(1000);
 
-        deepEqual(currency.id.id.toHex(), '85bbea6cc462b244'); // holds NAMESPACE_ID
+        deepEqual(currency.id.id.toHex(), 'bffb42a19116bdf6'); // holds NAMESPACE_ID
         expect(currency.amount.compact()).to.be.equal(1000 * 1000000);
     });
 
@@ -37,7 +36,7 @@ describe('NetworkCurrencyMosaic', () => {
     });
 
     it('should have valid statics', () => {
-        deepEqual(NetworkCurrencyMosaic.NAMESPACE_ID.id, new NamespaceId([3294802500, 2243684972]).id);
+        deepEqual(NetworkCurrencyMosaic.NAMESPACE_ID.id, new NamespaceId([2434186742, 3220914849]).id);
         expect(NetworkCurrencyMosaic.DIVISIBILITY).to.be.equal(6);
         expect(NetworkCurrencyMosaic.TRANSFERABLE).to.be.equal(true);
         expect(NetworkCurrencyMosaic.SUPPLY_MUTABLE).to.be.equal(false);

--- a/test/model/mosaic/NetworkCurrencyMosaic.spec.ts
+++ b/test/model/mosaic/NetworkCurrencyMosaic.spec.ts
@@ -35,10 +35,11 @@ describe('NetworkCurrencyMosaic', () => {
         expect(currency.toDTO().amount[0]).to.be.equal(1000 * 1000000);
     });
 
-    it('should have valid statics', () => {
-        deepEqual(NetworkCurrencyMosaic.NAMESPACE_ID.id, new NamespaceId([2434186742, 3220914849]).id);
-        expect(NetworkCurrencyMosaic.DIVISIBILITY).to.be.equal(6);
-        expect(NetworkCurrencyMosaic.TRANSFERABLE).to.be.equal(true);
-        expect(NetworkCurrencyMosaic.SUPPLY_MUTABLE).to.be.equal(false);
+    it('should have valid hardcoded default properties', () => {
+        const m = NetworkCurrencyMosaic.createAbsolute(0);
+        deepEqual(m.ID.id, new NamespaceId([2434186742, 3220914849]).id);
+        expect(m.DIVISIBILITY).to.be.equal(6);
+        expect(m.TRANSFERABLE).to.be.equal(true);
+        expect(m.SUPPLY_MUTABLE).to.be.equal(false);
     });
 });

--- a/test/model/mosaic/NetworkHarvestMosaic.spec.ts
+++ b/test/model/mosaic/NetworkHarvestMosaic.spec.ts
@@ -26,20 +26,21 @@ describe('NetworkHarvestMosaic', () => {
 
         const currency = NetworkHarvestMosaic.createRelative(1000);
 
-        deepEqual(currency.id.id.toHex(), '941299b2b7e1291c');
-        expect(currency.amount.compact()).to.be.equal(1000 * 1000);
+        deepEqual(currency.id.id.toHex(), 'bffb42a19116bdf6');
+        expect(currency.amount.compact()).to.be.equal(1000 * 1000000);
     });
 
     it('should set amount in smallest unit when toDTO()', () => {
 
         const currency = NetworkHarvestMosaic.createRelative(1000);
-        expect(currency.toDTO().amount[0]).to.be.equal(1000 * 1000);
+        expect(currency.toDTO().amount[0]).to.be.equal(1000 * 1000000);
     });
 
-    it('should have valid statics', () => {
-        deepEqual(NetworkHarvestMosaic.NAMESPACE_ID.id, new NamespaceId([3084986652, 2484246962]).id);
-        expect(NetworkHarvestMosaic.DIVISIBILITY).to.be.equal(3);
-        expect(NetworkHarvestMosaic.TRANSFERABLE).to.be.equal(true);
-        expect(NetworkHarvestMosaic.SUPPLY_MUTABLE).to.be.equal(true);
+    it('should have valid hardcoded default values', () => {
+        const h = NetworkHarvestMosaic.createAbsolute(0);
+        deepEqual(h.ID.id, new NamespaceId([2434186742, 3220914849]).id);
+        expect(h.DIVISIBILITY).to.be.equal(6);
+        expect(h.TRANSFERABLE).to.be.equal(true);
+        expect(h.SUPPLY_MUTABLE).to.be.equal(false);
     });
 });

--- a/test/model/transaction/HashLockTransaction.spec.ts
+++ b/test/model/transaction/HashLockTransaction.spec.ts
@@ -21,6 +21,7 @@ import {Deadline} from '../../../src/model/transaction/Deadline';
 import {HashLockTransaction} from '../../../src/model/transaction/HashLockTransaction';
 import {UInt64} from '../../../src/model/UInt64';
 import {TestingAccount} from '../../conf/conf.spec';
+import { XpxMosaicProperties } from '../../../src/model/mosaic/NetworkMosaic';
 
 describe('HashLockTransaction', () => {
     const account = TestingAccount;
@@ -38,7 +39,7 @@ describe('HashLockTransaction', () => {
             UInt64.fromUint(10),
             signedTransaction,
             NetworkType.MIJIN_TEST);
-        expect(transaction.mosaic.id).to.be.equal(NetworkCurrencyMosaic.NAMESPACE_ID);
+        expect(transaction.mosaic.id).to.be.equal(XpxMosaicProperties.ID);
         expect(transaction.mosaic.amount.compact()).to.be.equal(10000000);
         expect(transaction.hash).to.be.equal(signedTransaction.hash);
     });

--- a/test/model/transaction/LockFundsTransaction.spec.ts
+++ b/test/model/transaction/LockFundsTransaction.spec.ts
@@ -23,6 +23,7 @@ import {LockFundsTransaction} from '../../../src/model/transaction/LockFundsTran
 import {UInt64} from '../../../src/model/UInt64';
 import {TestingAccount} from '../../conf/conf.spec';
 import { DefaultFeeCalculationStrategy } from '../../../src/model/transaction/FeeCalculationStrategy';
+import { XpxMosaicProperties } from '../../../src/model/mosaic/NetworkMosaic';
 
 describe('LockFundsTransaction', () => {
     const account = TestingAccount;
@@ -78,7 +79,7 @@ describe('LockFundsTransaction', () => {
             UInt64.fromUint(10),
             signedTransaction,
             NetworkType.MIJIN_TEST);
-        deepEqual(transaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(transaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(transaction.mosaic.amount.compact()).to.be.equal(10000000);
         expect(transaction.hash).to.be.equal(signedTransaction.hash);
     });

--- a/test/model/transaction/SecretLockTransaction.spec.ts
+++ b/test/model/transaction/SecretLockTransaction.spec.ts
@@ -26,6 +26,7 @@ import {HashType} from '../../../src/model/transaction/HashType';
 import {SecretLockTransaction} from '../../../src/model/transaction/SecretLockTransaction';
 import {UInt64} from '../../../src/model/UInt64';
 import { DefaultFeeCalculationStrategy } from '../../../src/model/transaction/FeeCalculationStrategy';
+import { XpxMosaicProperties } from '../../../src/model/mosaic/NetworkMosaic';
 
 describe('SecretLockTransaction', () => {
 
@@ -75,7 +76,7 @@ describe('SecretLockTransaction', () => {
             recipient,
             NetworkType.MIJIN_TEST,
         );
-        deepEqual(secretLockTransaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(secretLockTransaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(secretLockTransaction.mosaic.amount.equals(UInt64.fromUint(10))).to.be.equal(true);
         expect(secretLockTransaction.duration.equals(UInt64.fromUint(100))).to.be.equal(true);
         expect(secretLockTransaction.hashType).to.be.equal(0);
@@ -110,7 +111,7 @@ describe('SecretLockTransaction', () => {
             recipient,
             NetworkType.MIJIN_TEST,
         );
-        deepEqual(secretLockTransaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(secretLockTransaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(secretLockTransaction.mosaic.amount.equals(UInt64.fromUint(10))).to.be.equal(true);
         expect(secretLockTransaction.duration.equals(UInt64.fromUint(100))).to.be.equal(true);
         expect(secretLockTransaction.hashType).to.be.equal(1);
@@ -144,7 +145,7 @@ describe('SecretLockTransaction', () => {
             recipient,
             NetworkType.MIJIN_TEST,
         );
-        deepEqual(secretLockTransaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(secretLockTransaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(secretLockTransaction.mosaic.amount.equals(UInt64.fromUint(10))).to.be.equal(true);
         expect(secretLockTransaction.duration.equals(UInt64.fromUint(100))).to.be.equal(true);
         expect(secretLockTransaction.hashType).to.be.equal(2);
@@ -178,7 +179,7 @@ describe('SecretLockTransaction', () => {
             recipient,
             NetworkType.MIJIN_TEST,
         );
-        deepEqual(secretLockTransaction.mosaic.id.id, NetworkCurrencyMosaic.NAMESPACE_ID.id);
+        deepEqual(secretLockTransaction.mosaic.id.id, XpxMosaicProperties.ID.id);
         expect(secretLockTransaction.mosaic.amount.equals(UInt64.fromUint(10))).to.be.equal(true);
         expect(secretLockTransaction.duration.equals(UInt64.fromUint(100))).to.be.equal(true);
         expect(secretLockTransaction.hashType).to.be.equal(3);

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -105,7 +105,7 @@ describe('TransferTransaction', () => {
             signedTransaction.payload.length,
         )).to.be.equal(
             '9050B9837EFAB4BBE8A4B9BB32D812F9885C00D8FC1650E1420D000100746573742D6D657373616765' +
-            '44B262C46CEABB8500E1F50500000000');
+            'F6BD1691A142FBBF00E1F50500000000');
     });
 
     it('should createComplete an TransferTransaction object with NamespaceId recipient', () => {
@@ -132,7 +132,7 @@ describe('TransferTransaction', () => {
             244,
             signedTransaction.payload.length,
         )).to.be.equal('9151776168D24257D8000000000000000000000000000000000D000100746573742D6D657373616765' +
-            '44B262C46CEABB8500E1F50500000000');
+            'F6BD1691A142FBBF00E1F50500000000');
     });
 
     it('should format TransferTransaction payload with 25 bytes binary address', () => {


### PR DESCRIPTION
- updated NetworkCurrencyMosaic and NetworkHarvestMosaic to use prx.xpx namespace by default
- removed node 9, added node 12 (since it is LTS now) + fix tests, remove Buffer constructor usage warning