### PR TITLE
Yaaccount/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
     - "node_modules"
 before_script:
   - npm run build
-script: 
-  - npm run test:coveralls
+script:
+  - node_version=$(node -v); if [ ${node_version:1:2} = 12 ]; then npm run test:coveralls; else npm run test; fi
 deploy:
   provider: npm
   skip-cleanup: true
@@ -17,4 +17,4 @@ deploy:
   api_key: "$AUTH_TOKEN"
   on:
     branch: master
-    node: 10
+    node: 12

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -1168,6 +1168,7 @@ describe('TransactionHttp', () => {
                 });
             });
         });
+
         describe('ChainUpgradeTransaction', () => {
             ((NemesisAccount.privateKey !== "0".repeat(64)) ? it : it.skip)('standalone', (done) => {
                 const chainUpgradeTransaction = factory.chainUpgrade()
@@ -1201,6 +1202,28 @@ describe('TransactionHttp', () => {
                     .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
+
+            it('aggregate', (done) => {
+                const offers = [
+                    new AddExchangeOffer(
+                        ConfTestingMosaicId,
+                        UInt64.fromUint(10000000),
+                        UInt64.fromUint(10000000),
+                        ExchangeOfferType.BUY_OFFER,
+                        UInt64.fromUint(1000)
+                    )
+                ];
+                const addExchangeOfferTransaction = factory.addExchangeOffer()
+                    .offers(offers)
+                    .build();
+                const aggregateComplete = factory.aggregateComplete()
+                    .innerTransactions([addExchangeOfferTransaction.toAggregate(CosignatoryAccount.publicAccount)])
+                    .build();
+                const signedTransaction = aggregateComplete.signWith(CosignatoryAccount, factory.generationHash);
+                validateTransactionConfirmed(listener, CosignatoryAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
         });
 
         describe('ExchangeOfferTransaction', () => {
@@ -1222,6 +1245,28 @@ describe('TransactionHttp', () => {
                     .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });
+
+            it('aggregate', (done) => {
+                const offers = [
+                    new ExchangeOffer(
+                        ConfTestingMosaicId,
+                        UInt64.fromUint(100),
+                        UInt64.fromUint(100),
+                        ExchangeOfferType.BUY_OFFER,
+                        CosignatoryAccount.publicAccount
+                    )
+                ];
+                const exchangeOfferTransaction = factory.exchangeOffer()
+                    .offers(offers)
+                    .build();
+                const aggregateComplete = factory.aggregateComplete()
+                    .innerTransactions([exchangeOfferTransaction.toAggregate(TestingAccount.publicAccount)])
+                    .build();
+                const signedTransaction = aggregateComplete.signWith(TestingAccount, factory.generationHash);
+                validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
         });
 
         describe('RemoveExchangeOfferTransaction', () => {
@@ -1237,6 +1282,25 @@ describe('TransactionHttp', () => {
                     .build();
                 const signedTransaction = exchangeOfferTransaction.signWith(TestingAccount, factory.generationHash);
                 validateTransactionConfirmed(listener, TestingAccount.address, signedTransaction.hash)
+                    .then(() => done()).catch((reason) => fail(reason));
+                transactionHttp.announce(signedTransaction);
+            });
+
+            it('aggregate', (done) => {
+                const offers = [
+                    new RemoveExchangeOffer(
+                        ConfTestingMosaicId,
+                        ExchangeOfferType.BUY_OFFER,
+                    )
+                ];
+                const exchangeOfferTransaction = factory.removeExchangeOffer()
+                    .offers(offers)
+                    .build();
+                const aggregateComplete = factory.aggregateComplete()
+                    .innerTransactions([exchangeOfferTransaction.toAggregate(CosignatoryAccount.publicAccount)])
+                    .build();
+                const signedTransaction = aggregateComplete.signWith(CosignatoryAccount, factory.generationHash);
+                validateTransactionConfirmed(listener, CosignatoryAccount.address, signedTransaction.hash)
                     .then(() => done()).catch((reason) => fail(reason));
                 transactionHttp.announce(signedTransaction);
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,12 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-spies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-1.0.0.tgz",
+      "integrity": "sha512-elF2ZUczBsFoP07qCfMO/zeggs8pqCf3fZGyK5+2X4AndS8jycZYID91ztD9oQ7d/0tnS963dPkd0frQEThDsg==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "include": [
       "src"
     ],
-    "exclude": [],
+    "exclude": [
+      "src/infrastructure/api"
+    ],
     "sourceMap": true,
     "instrument": true,
     "all": true

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
       "src"
     ],
     "exclude": [
-      "src/infrastructure/api"
+      "src/infrastructure/api",
+      "src/infrastructure/buffers"
     ],
     "sourceMap": true,
     "instrument": true,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/ws": "^6.0.1",
     "assert": "^2.0.0",
     "chai": "^4.2.0",
+    "chai-spies": "^1.0.0",
     "config": "^3.2.2",
     "coveralls": "^3.0.5",
     "mocha": "^6.2.0",

--- a/src/infrastructure/NamespaceHttp.ts
+++ b/src/infrastructure/NamespaceHttp.ts
@@ -177,23 +177,22 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
      * @returns Observable<MosaicId | null>
      */
     public getLinkedMosaicId(namespaceId: NamespaceId): Observable<MosaicId> {
-        return this.getNetworkTypeObservable().pipe(
-            mergeMap((networkType) => observableFrom(
-                this.namespaceRoutesApi.getNamespace(namespaceId.toHex())).pipe(
-                map((namespaceInfoDTO: NamespaceInfoDTO) => {
+        return observableFrom(
+            this.namespaceRoutesApi.getNamespace(namespaceId.toHex())).pipe(
+            map((namespaceInfoDTO: NamespaceInfoDTO) => {
 
-                    if (namespaceInfoDTO.namespace === undefined) {
-                        // forward js-xpx-chain-rest error
-                        throw namespaceInfoDTO;
-                    }
+                if (namespaceInfoDTO.namespace === undefined) {
+                    // forward js-xpx-chain-rest error
+                    throw namespaceInfoDTO;
+                }
 
-                    if (namespaceInfoDTO.namespace.alias.type === AliasType.None
-                        || namespaceInfoDTO.namespace.alias.type !== AliasType.Mosaic
-                        || !namespaceInfoDTO.namespace.alias.mosaicId) {
-                        throw new Error('No mosaicId is linked to namespace \'' + namespaceInfoDTO.namespace.level0 + '\'');
-                    }
-                    return new MosaicId(namespaceInfoDTO.namespace.alias.mosaicId);
-                }))));
+                if (namespaceInfoDTO.namespace.alias.type === AliasType.None
+                    || namespaceInfoDTO.namespace.alias.type !== AliasType.Mosaic
+                    || !namespaceInfoDTO.namespace.alias.mosaicId) {
+                    throw new Error('No mosaicId is linked to namespace \'' + namespaceInfoDTO.namespace.level0 + '\'');
+                }
+                return new MosaicId(namespaceInfoDTO.namespace.alias.mosaicId);
+            }));
     }
 
     /**
@@ -202,26 +201,25 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
      * @returns Observable<Address>
      */
     public getLinkedAddress(namespaceId: NamespaceId): Observable<Address> {
-        return this.getNetworkTypeObservable().pipe(
-            mergeMap((networkType) => observableFrom(
-                this.namespaceRoutesApi.getNamespace(namespaceId.toHex())).pipe(
-                map((namespaceInfoDTO: NamespaceInfoDTO) => {
+        return observableFrom(
+            this.namespaceRoutesApi.getNamespace(namespaceId.toHex())).pipe(
+            map((namespaceInfoDTO: NamespaceInfoDTO) => {
 
-                    if (namespaceInfoDTO.namespace === undefined) {
-                        // forward js-xpx-chain-rest error
-                        throw namespaceInfoDTO;
-                    }
+                if (namespaceInfoDTO.namespace === undefined) {
+                    // forward js-xpx-chain-rest error
+                    throw namespaceInfoDTO;
+                }
 
-                    if (namespaceInfoDTO.namespace.alias.type === AliasType.None
-                        || namespaceInfoDTO.namespace.alias.type !== AliasType.Address
-                        || !namespaceInfoDTO.namespace.alias.address) {
-                        throw new Error('No address is linked to namespace \'' + namespaceInfoDTO.namespace.level0 + '\'');
-                    }
+                if (namespaceInfoDTO.namespace.alias.type === AliasType.None
+                    || namespaceInfoDTO.namespace.alias.type !== AliasType.Address
+                    || !namespaceInfoDTO.namespace.alias.address) {
+                    throw new Error('No address is linked to namespace \'' + namespaceInfoDTO.namespace.level0 + '\'');
+                }
 
-                    const addressDecoded = namespaceInfoDTO.namespace.alias.address;
-                    const address = AddressLibrary.addressToString(convert.hexToUint8(addressDecoded));
-                    return Address.createFromRawAddress(address);
-                }))));
+                const addressDecoded = namespaceInfoDTO.namespace.alias.address;
+                const address = AddressLibrary.addressToString(convert.hexToUint8(addressDecoded));
+                return Address.createFromRawAddress(address);
+            }));
     }
 
     private extractLevels(namespace: any): NamespaceId[] {
@@ -247,9 +245,11 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
      */
     private extractAlias(namespace: any): Alias {
         if (namespace.alias && namespace.alias.type === AliasType.Mosaic) {
-            return new MosaicAlias(namespace.alias.type, namespace.alias.mosaicId);
+            return new MosaicAlias(namespace.alias.type, new MosaicId(namespace.alias.mosaicId));
         } else if (namespace.alias && namespace.alias.type === AliasType.Address) {
-            return new AddressAlias(namespace.alias.type, namespace.alias.address);
+            const addressDecoded = namespace.alias.address;
+            const address = AddressLibrary.addressToString(convert.hexToUint8(addressDecoded));
+            return new AddressAlias(namespace.alias.type, Address.createFromRawAddress(address));
         }
 
         return new EmptyAlias();

--- a/test/infrastructure/AccountHttp.spec.ts
+++ b/test/infrastructure/AccountHttp.spec.ts
@@ -1,0 +1,314 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { AccountHttp } from '../../src/infrastructure/infrastructure';
+import { deepEqual } from 'assert';
+import * as createFromDto from '../../src/infrastructure/transaction/CreateTransactionFromDTO';
+import * as dtoMapping from '../../src/core/utils/DtoMapping'
+import { Address, NetworkType, PublicAccount, UInt64, MultisigAccountInfo } from '../../src/model/model';
+import { RawAddress, Convert } from '../../src/core/format';
+import { of } from 'rxjs';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new AccountHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('AccountHttps', () => {
+
+    describe('getAccountInfo', () => {
+        const dto = {
+            meta: 'some-meta',
+            account: {
+                address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())),
+                addressHeight: UInt64.fromUint(666).toDTO(),
+                publicKey: publicAccount.publicKey,
+                publicKeyHeight: UInt64.fromUint(777).toDTO(),
+                mosaics: [
+                    {
+                        id: UInt64.fromUint(888).toDTO(),
+                        amount: UInt64.fromUint(999).toDTO()
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountInfo', (tx) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountInfo(address).subscribe(response => {
+                expect(response.meta).to.be.equal(dto.meta);
+                expect(response.address.plain()).to.be.equal(Address.createFromRawAddress(RawAddress.addressToString(Convert.hexToUint8(dto.account.address))).plain());
+                deepEqual(response.addressHeight.toDTO(), dto.account.addressHeight);
+                expect(response.publicKey).to.be.equal(dto.account.publicKey);
+                expect(response.publicAccount.publicKey).to.be.equal(dto.account.publicKey);
+                deepEqual(response.publicKeyHeight.toDTO(), dto.account.publicKeyHeight);
+                expect(response.mosaics.length).to.be.equal(dto.account.mosaics.length);
+                deepEqual(response.mosaics[0].id.toDTO().id, dto.account.mosaics[0].id);
+                deepEqual(response.mosaics[0].amount.toDTO(), dto.account.mosaics[0].amount);
+                done();
+            })
+        });
+    });
+
+    describe('getAccountsInfo', () => {
+        const dto = {
+            meta: 'some-meta',
+            account: {
+                address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())),
+                addressHeight: UInt64.fromUint(666).toDTO(),
+                publicKey: publicAccount.publicKey,
+                publicKeyHeight: UInt64.fromUint(777).toDTO(),
+                mosaics: [
+                    {
+                        id: UInt64.fromUint(888).toDTO(),
+                        amount: UInt64.fromUint(999).toDTO()
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountsInfo', (tx) => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountsInfo([address]).subscribe(responses => {
+                expect(responses.length).to.be.equal(1);
+                responses.forEach(response => {
+                    expect(response.meta).to.be.equal(dto.meta);
+                    expect(response.address.plain()).to.be.equal(Address.createFromRawAddress(RawAddress.addressToString(Convert.hexToUint8(dto.account.address))).plain());
+                    deepEqual(response.addressHeight.toDTO(), dto.account.addressHeight);
+                    expect(response.publicKey).to.be.equal(dto.account.publicKey);
+                    expect(response.publicAccount.publicKey).to.be.equal(dto.account.publicKey);
+                    deepEqual(response.publicKeyHeight.toDTO(), dto.account.publicKeyHeight);
+                    expect(response.mosaics.length).to.be.equal(dto.account.mosaics.length);
+                    deepEqual(response.mosaics[0].id.toDTO().id, dto.account.mosaics[0].id);
+                    deepEqual(response.mosaics[0].amount.toDTO(), dto.account.mosaics[0].amount);
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getAccountRestrictions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountRestrictions', (tx) => Promise.resolve('api called'));
+            sandbox.on(dtoMapping.DtoMapping, 'extractAccountRestrictionFromDto', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountRestrictions(address).subscribe(response => {
+                expect(response).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('getAccountRestrictionsFromAccounts', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountRestrictionsFromAccounts', (tx) => Promise.resolve(['api called']));
+            sandbox.on(dtoMapping.DtoMapping, 'extractAccountRestrictionFromDto', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountRestrictionsFromAccounts([address]).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('getAccountsNames', () => {
+        const dto = {
+            address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())),
+            names: ['some.name']
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountsNames', (tx) => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountsNames([address]).subscribe(responses => {
+                expect(responses.length).to.be.equal(1);
+                responses.forEach(response => {
+                    expect(response.address.plain()).to.be.equal(Address.createFromRawAddress(RawAddress.addressToString(Convert.hexToUint8(dto.address))).plain());
+                    expect(response.names.length).to.be.equal(1);
+                    expect(response.names[0].name).to.be.equal('some.name');
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getMultisigAccountInfo', () => {
+        const dto = {
+            multisig: {
+                account: publicAccount.publicKey,
+                minApproval: 2,
+                minRemoval: 3,
+                cosignatories: [publicAccount.publicKey],
+                multisigAccounts: [publicAccount.publicKey]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountMultisig', (tx) => Promise.resolve(dto));
+            sandbox.on((client as any).networkHttp, 'getNetworkType', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMultisigAccountInfo(address).subscribe(response => {
+                expect(response.account.publicKey).to.be.equal(dto.multisig.account);
+                expect(response.minApproval).to.be.equal(dto.multisig.minApproval);
+                expect(response.minRemoval).to.be.equal(dto.multisig.minRemoval);
+                expect(response.cosignatories.length).to.be.equal(1);
+                expect(response.cosignatories[0].publicKey).to.be.equal(dto.multisig.cosignatories[0]);
+                expect(response.multisigAccounts.length).to.be.equal(1);
+                expect(response.multisigAccounts[0].publicKey).to.be.equal(dto.multisig.multisigAccounts[0]);
+                done();
+            })
+        });
+    });
+
+    describe('getMultisigAccountGraphInfo', () => {
+        const dto = {
+            level: 666,
+            multisigEntries: [{
+                multisig: {
+                    account: publicAccount.publicKey,
+                    minApproval: 2,
+                    minRemoval: 3,
+                    cosignatories: [publicAccount.publicKey],
+                    multisigAccounts: [publicAccount.publicKey]
+                }
+            }]
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'getAccountMultisigGraph', (tx) => Promise.resolve([dto]));
+            sandbox.on((client as any).networkHttp, 'getNetworkType', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMultisigAccountGraphInfo(address).subscribe(responses => {
+                expect(responses.multisigAccounts.size).to.be.equal(1);
+                expect(responses.multisigAccounts.get(666)).not.to.be.undefined;
+                (responses.multisigAccounts.get(666) as MultisigAccountInfo[]).forEach(response => {
+                    expect(dto.multisigEntries.length).to.be.equal(1);
+                    expect(response.account.publicKey).to.be.equal(dto.multisigEntries[0].multisig.account);
+                    expect(response.minApproval).to.be.equal(dto.multisigEntries[0].multisig.minApproval);
+                    expect(response.minRemoval).to.be.equal(dto.multisigEntries[0].multisig.minRemoval);
+                    expect(response.cosignatories.length).to.be.equal(1);
+                    expect(response.cosignatories[0].publicKey).to.be.equal(dto.multisigEntries[0].multisig.cosignatories[0]);
+                    expect(response.multisigAccounts.length).to.be.equal(1);
+                    expect(response.multisigAccounts[0].publicKey).to.be.equal(dto.multisigEntries[0].multisig.multisigAccounts[0]);
+                });
+                done();
+            })
+        });
+    });
+
+    describe('transactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'transactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.transactions(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('incomingTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'incomingTransactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.incomingTransactions(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('outgoingTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'outgoingTransactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.outgoingTransactions(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('unconfirmedTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'unconfirmedTransactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.unconfirmedTransactions(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('aggregateBondedTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).accountRoutesApi, 'partialTransactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.aggregateBondedTransactions(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+});

--- a/test/infrastructure/AccountHttp.spec.ts
+++ b/test/infrastructure/AccountHttp.spec.ts
@@ -18,7 +18,7 @@ const networkType = NetworkType.MIJIN_TEST;
 const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
 const address = publicAccount.address;
 
-describe('AccountHttps', () => {
+describe('AccountHttp', () => {
 
     describe('getAccountInfo', () => {
         const dto = {

--- a/test/infrastructure/BlockHttp.spec.ts
+++ b/test/infrastructure/BlockHttp.spec.ts
@@ -1,0 +1,40 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { BlockHttp } from '../../src/infrastructure/infrastructure';
+import { deepEqual } from 'assert';
+import * as createFromDto from '../../src/infrastructure/transaction/CreateTransactionFromDTO';
+import * as dtoMapping from '../../src/core/utils/DtoMapping'
+import { NetworkType, PublicAccount } from '../../src/model/model';
+import { RawAddress, Convert } from '../../src/core/format';
+import { of } from 'rxjs';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new BlockHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('BlockHttp', () => {
+
+    describe('getBlockTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).blockRoutesApi, 'getBlockTransactions', (number) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called' : 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getBlockTransactions(666).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                expect(response[0]).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+});

--- a/test/infrastructure/ChainConfigHttp.spec.ts
+++ b/test/infrastructure/ChainConfigHttp.spec.ts
@@ -1,0 +1,38 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { ChainConfigHttp } from '../../src/infrastructure/infrastructure';
+import { UInt64 } from '../../src/model/model';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new ChainConfigHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+describe('ChainConfigHttp', () => {
+
+    describe('getChainConfig', () => {
+        const dto = {
+            networkConfig: {
+                height: UInt64.fromUint(666).toDTO(),
+                networkConfig: 'some network config',
+                supportedEntityVersions: 'some supported entity versions'
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).configRoutesApi, 'getConfig', (number) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getChainConfig(666).subscribe(response => {
+                expect(response.height.compact()).to.be.equal(666);
+                expect(response.networkConfig).to.be.equal('some network config');
+                expect(response.supportedEntityVersions).to.be.equal('some supported entity versions');
+                done();
+            })
+        });
+    });
+
+});

--- a/test/infrastructure/ChainHttp.spec.ts
+++ b/test/infrastructure/ChainHttp.spec.ts
@@ -1,0 +1,52 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { ChainHttp } from '../../src/infrastructure/infrastructure';
+import { UInt64 } from '../../src/model/model';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new ChainHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+describe('ChainHttp', () => {
+
+    describe('getBlockchainHeight', () => {
+        const dto = {
+            height: UInt64.fromUint(666).toDTO(),
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).chainRoutesApi, 'getBlockchainHeight', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getBlockchainHeight().subscribe(response => {
+                expect(response.compact()).to.be.equal(666);
+                done();
+            })
+        });
+    });
+
+    describe('getBlockchainScore', () => {
+        const dto = {
+            scoreLow: UInt64.fromUint(666).toDTO(),
+            scoreHigh: UInt64.fromUint(999).toDTO(),
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).chainRoutesApi, 'getBlockchainScore', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getBlockchainScore().subscribe(response => {
+                expect(response.scoreLow.compact()).to.be.equal(666);
+                expect(response.scoreHigh.compact()).to.be.equal(999);
+                done();
+            })
+        });
+    });
+
+});

--- a/test/infrastructure/ChainUpgradeHttp.spec.ts
+++ b/test/infrastructure/ChainUpgradeHttp.spec.ts
@@ -1,0 +1,35 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { ChainUpgradeHttp } from '../../src/infrastructure/infrastructure';
+import { UInt64 } from '../../src/model/model';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new ChainUpgradeHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+describe('ChainUpgradeHttp', () => {
+
+    describe('getChainUpgrade', () => {
+        const dto = {
+            blockchainUpgrade: {
+                height: UInt64.fromUint(666).toDTO(),
+                blockChainVersion: UInt64.fromUint(999).toDTO()
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).upgradeRoutesApi, 'getUpgrade', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getChainUpgrade(666).subscribe(response => {
+                expect(response.height.compact()).to.be.equal(666);
+                expect(response.catapultVersion.compact()).to.be.equal(999);
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/ContractsHttp.spec.ts
+++ b/test/infrastructure/ContractsHttp.spec.ts
@@ -1,0 +1,142 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { ContractHttp } from '../../src/infrastructure/infrastructure';
+import { UInt64, NetworkType, PublicAccount } from '../../src/model/model';
+import { deepEqual } from 'assert';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new ContractHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('ContractHttp', () => {
+
+    describe('getAccountContract', () => {
+        const dto = {
+            contract: {
+                multisig: 'some multisig',
+                multisigAddress: 'some multisig address',
+                start: UInt64.fromUint(666).toDTO(),
+                duration: UInt64.fromUint(999).toDTO(),
+                hash: 'some hash',
+                customers: ['some customer'],
+                executors: ['some executor'],
+                verifiers: ['some verifier']
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).contractRoutesApi, 'getAccountContract', () => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountContract(publicAccount).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                deepEqual({// pre-process response so we can use deepEqual directly
+                    ...response[0],
+                    start: response[0].start.toDTO(),
+                    duration: response[0].duration.toDTO()
+                }, dto.contract);
+                done();
+            })
+        });
+    });
+    describe('getAccountsContracts', () => {
+        const dto = {
+            contract: {
+                multisig: 'some multisig',
+                multisigAddress: 'some multisig address',
+                start: UInt64.fromUint(666).toDTO(),
+                duration: UInt64.fromUint(999).toDTO(),
+                hash: 'some hash',
+                customers: ['some customer'],
+                executors: ['some executor'],
+                verifiers: ['some verifier']
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).contractRoutesApi, 'getAccountContracts', () => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountsContracts([publicAccount]).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                deepEqual({// pre-process response so we can use deepEqual directly
+                    ...response[0],
+                    start: response[0].start.toDTO(),
+                    duration: response[0].duration.toDTO()
+                }, dto.contract);
+                done();
+            })
+        });
+    });
+    describe('getContract', () => {
+        const dto = {
+            contract: {
+                multisig: 'some multisig',
+                multisigAddress: 'some multisig address',
+                start: UInt64.fromUint(666).toDTO(),
+                duration: UInt64.fromUint(999).toDTO(),
+                hash: 'some hash',
+                customers: ['some customer'],
+                executors: ['some executor'],
+                verifiers: ['some verifier']
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).contractRoutesApi, 'getContract', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getContract(address).subscribe(response => {
+                deepEqual({// pre-process response so we can use deepEqual directly
+                    ...response,
+                    start: response.start.toDTO(),
+                    duration: response.duration.toDTO()
+                }, dto.contract);
+                done();
+            })
+        });
+    });
+    describe('getContracts', () => {
+        const dto = {
+            contract: {
+                multisig: 'some multisig',
+                multisigAddress: 'some multisig address',
+                start: UInt64.fromUint(666).toDTO(),
+                duration: UInt64.fromUint(999).toDTO(),
+                hash: 'some hash',
+                customers: ['some customer'],
+                executors: ['some executor'],
+                verifiers: ['some verifier']
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).contractRoutesApi, 'getContracts', () => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getContracts([address]).subscribe(response => {
+                expect(response.length).to.be.equal(1);
+                deepEqual({// pre-process response so we can use deepEqual directly
+                    ...response[0],
+                    start: response[0].start.toDTO(),
+                    duration: response[0].duration.toDTO()
+                }, dto.contract);
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/DiagnosticHttp.spec.ts
+++ b/test/infrastructure/DiagnosticHttp.spec.ts
@@ -1,0 +1,55 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { DiagnosticHttp } from '../../src/infrastructure/infrastructure';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new DiagnosticHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+describe('DiagnosticHttp', () => {
+
+    describe('getDiagnosticStorage', () => {
+        const dto = {
+            numAccounts: 333,
+            numBlocks: 666,
+            numTransactions: 999
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).diagnosticRoutesApi, 'getDiagnosticStorage', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getDiagnosticStorage().subscribe(response => {
+                expect(response.numAccounts).to.be.equal(333);
+                expect(response.numBlocks).to.be.equal(666);
+                expect(response.numTransactions).to.be.equal(999);
+                done();
+            })
+        });
+    });
+    describe('getServerInfo', () => {
+        const dto = {
+            serverInfo: {
+                restVersion: 'some rest version',
+                sdkVersion: 'some sdk version'
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).diagnosticRoutesApi, 'getServerInfo', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getServerInfo().subscribe(response => {
+                expect(response.restVersion).to.be.equal('some rest version');
+                expect(response.sdkVersion).to.be.equal('some sdk version');
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/MetadataHttp.spec.ts
+++ b/test/infrastructure/MetadataHttp.spec.ts
@@ -1,0 +1,115 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { MetadataHttp } from '../../src/infrastructure/infrastructure';
+import { NetworkType, PublicAccount, NamespaceId, MosaicId } from '../../src/model/model';
+import { Convert, RawAddress } from '../../src/core/format';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new MetadataHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('MetadataHttp', () => {
+
+    describe('getAccountMetadata', () => {
+        const dto = {
+            metadata: {
+                metadataId: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())),
+                metadataType: 666,
+                fields: [
+                    {
+                        key: 'some key',
+                        value: 'some value'
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).metadataRoutesApi, 'getAccountMetadata', (number) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getAccountMetadata(address.plain()).subscribe(response => {
+                expect(response.metadataId.plain()).to.be.equal(address.plain());
+                expect(response.metadataType).to.be.equal(666);
+                expect(response.fields.length).to.be.equal(1);
+                expect(response.fields[0].key).to.be.equal('some key');
+                expect(response.fields[0].value).to.be.equal('some value');
+                done();
+            })
+        });
+    });
+
+    describe('getNamespaceMetadata', () => {
+        const namespaceId = new NamespaceId([66666,99999]);
+        const dto = {
+            metadata: {
+                metadataId: namespaceId.toDTO().id,
+                metadataType: 666,
+                fields: [
+                    {
+                        key: 'some key',
+                        value: 'some value'
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).metadataRoutesApi, 'getNamespaceMetadata', (number) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getNamespaceMetadata(namespaceId).subscribe(response => {
+                expect(response.metadataId.toDTO().id[0]).to.be.equal(66666);
+                expect(response.metadataId.toDTO().id[1]).to.be.equal(99999);
+                expect(response.metadataType).to.be.equal(666);
+                expect(response.fields.length).to.be.equal(1);
+                expect(response.fields[0].key).to.be.equal('some key');
+                expect(response.fields[0].value).to.be.equal('some value');
+                done();
+            })
+        });
+    });
+
+    describe('getMosaicMetadata', () => {
+        const mosaicId = new MosaicId([66666,99999]);
+        const dto = {
+            metadata: {
+                metadataId: mosaicId.toDTO().id,
+                metadataType: 666,
+                fields: [
+                    {
+                        key: 'some key',
+                        value: 'some value'
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).metadataRoutesApi, 'getMosaicMetadata', (number) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMosaicMetadata(mosaicId).subscribe(response => {
+                expect(response.metadataId.toDTO().id[0]).to.be.equal(66666);
+                expect(response.metadataId.toDTO().id[1]).to.be.equal(99999);
+                expect(response.metadataType).to.be.equal(666);
+                expect(response.fields.length).to.be.equal(1);
+                expect(response.fields[0].key).to.be.equal('some key');
+                expect(response.fields[0].value).to.be.equal('some value');
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/MosaicHttp.spec.ts
+++ b/test/infrastructure/MosaicHttp.spec.ts
@@ -1,0 +1,145 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { MosaicHttp } from '../../src/infrastructure/infrastructure';
+import { NetworkType, PublicAccount, MosaicId, UInt64 } from '../../src/model/model';
+import { of } from 'rxjs';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new MosaicHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('MosaicHttp', () => {
+
+    describe('getMosaic', () => {
+        const mosaicId = new MosaicId([66666,99999]);
+        const dto = {
+            meta: {
+                id: 'some meta id'
+            },
+            mosaic: {
+                mosaicId: mosaicId.toDTO().id,
+                supply: UInt64.fromUint(1000000).toDTO(),
+                height: UInt64.fromUint(666).toDTO(),
+                owner: publicAccount.publicKey,
+                revision: 33333,
+                properties: [{
+                        value: UInt64.fromUint(3).toDTO(), // mutable = true, transferable = true
+                    },{
+                        value: UInt64.fromUint(5).toDTO(), // divisibility
+                    },{
+                        value: UInt64.fromUint(12345).toDTO() // duration
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).mosaicRoutesApi, 'getMosaic', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMosaic(mosaicId).subscribe(response => {
+                expect(response.metaId).to.be.equal('some meta id');
+                expect(response.divisibility).to.be.equal(5);
+                expect(response.isSupplyMutable()).to.be.equal(true);
+                expect(response.isTransferable()).to.be.equal(true);
+                expect((response.duration as any).compact()).to.be.equal(12345);
+                expect(response.height.compact()).to.be.equal(666);
+                expect(response.mosaicId.toDTO().id[0]).to.be.equal(66666);
+                expect(response.mosaicId.toDTO().id[1]).to.be.equal(99999);
+                expect(response.owner.publicKey).to.be.equal(publicAccount.publicKey);
+                expect(response.revision).to.be.equal(33333);
+                expect(response.supply.compact()).to.be.equal(1000000);
+                done();
+            })
+        });
+    });
+
+    describe('getMosaics', () => {
+        const mosaicId = new MosaicId([66666,99999]);
+        const dto = {
+            meta: {
+                id: 'some meta id'
+            },
+            mosaic: {
+                mosaicId: mosaicId.toDTO().id,
+                supply: UInt64.fromUint(1000000).toDTO(),
+                height: UInt64.fromUint(666).toDTO(),
+                owner: publicAccount.publicKey,
+                revision: 33333,
+                properties: [{
+                        value: UInt64.fromUint(3).toDTO(), // mutable = true, transferable = true
+                    },{
+                        value: UInt64.fromUint(5).toDTO(), // divisibility
+                    },{
+                        value: UInt64.fromUint(12345).toDTO() // duration
+                    }
+                ]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).mosaicRoutesApi, 'getMosaics', () => Promise.resolve([dto]));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMosaics([mosaicId]).subscribe(responses => {
+                expect(responses.length).to.be.equal(1);
+                responses.forEach(response => {
+                    expect(response.metaId).to.be.equal('some meta id');
+                    expect(response.divisibility).to.be.equal(5);
+                    expect(response.isSupplyMutable()).to.be.equal(true);
+                    expect(response.isTransferable()).to.be.equal(true);
+                    expect((response.duration as any).compact()).to.be.equal(12345);
+                    expect(response.height.compact()).to.be.equal(666);
+                    expect(response.mosaicId.toDTO().id[0]).to.be.equal(66666);
+                    expect(response.mosaicId.toDTO().id[1]).to.be.equal(99999);
+                    expect(response.owner.publicKey).to.be.equal(publicAccount.publicKey);
+                    expect(response.revision).to.be.equal(33333);
+                    expect(response.supply.compact()).to.be.equal(1000000);
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getMosaicsNames', () => {
+        const mosaicId = new MosaicId([66666,99999]);
+        const dto = {
+            mosaicId: mosaicId.toDTO().id,
+            names: [
+                'some.name',
+                'some.other.name'
+            ]
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).mosaicRoutesApi, 'getMosaicsNames', () => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getMosaicsNames([mosaicId]).subscribe(responses => {
+                expect(responses.length).to.be.equal(1);
+                responses.forEach(response => {
+                    expect(response.mosaicId.toDTO().id[0]).to.be.equal(66666);
+                    expect(response.mosaicId.toDTO().id[1]).to.be.equal(99999);
+                    expect(response.names.length).to.be.equal(2);
+                    expect(response.names[0].name).to.be.equal('some.name');
+                    expect(response.names[1].name).to.be.equal('some.other.name');
+                });
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/NamespaceHttp.spec.ts
+++ b/test/infrastructure/NamespaceHttp.spec.ts
@@ -1,0 +1,369 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { NamespaceHttp } from '../../src/infrastructure/infrastructure';
+import { NetworkType, PublicAccount, MosaicId, UInt64, NamespaceId, NamespaceType, NamespaceInfo, AliasType } from '../../src/model/model';
+import { of } from 'rxjs';
+import { RawAddress, Convert } from '../../src/core/format';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new NamespaceHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('NamespaceHttp', () => {
+
+    describe('getNamespace', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Address,
+                    address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    // mosaicId:, // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespace', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getNamespace(new NamespaceId('grand.parent.child')).subscribe(response => {
+                expect(response.active).to.be.equal(true);
+                expect(response.index).to.be.equal(666);
+                expect(response.metaId).to.be.equal('some meta id');
+                expect(response.isRoot()).to.be.equal(false);
+                expect(response.depth).to.be.equal(3);
+                expect(response.levels.length).to.be.equal(3);
+                expect(response.levels[0].fullName).to.be.equal('grand');
+                expect(response.levels[1].fullName).to.be.equal('grand.parent');
+                expect(response.levels[2].fullName).to.be.equal('grand.parent.child');
+                expect(response.parentNamespaceId().fullName).to.be.equal('grand.parent');
+                expect(response.owner.publicKey).to.be.equal(publicAccount.publicKey);
+                expect(response.startHeight.compact()).to.be.equal(666666);
+                expect(response.endHeight.compact()).to.be.equal(999999);
+                expect(response.alias.type).to.be.equal(AliasType.Address);
+                expect((response.alias.address as any).plain()).to.be.equal(address.plain());
+                done();
+            })
+        });
+    });
+
+    describe('getNamespacesFromAccount', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Address,
+                    address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    // mosaicId:, // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespacesFromAccount', () => Promise.resolve([dto]));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getNamespacesFromAccount(address).subscribe(responses => {
+                responses.forEach(response => {
+                    expect(responses.length).to.be.equal(1);
+                    expect(response.active).to.be.equal(true);
+                    expect(response.index).to.be.equal(666);
+                    expect(response.metaId).to.be.equal('some meta id');
+                    expect(response.isRoot()).to.be.equal(false);
+                    expect(response.depth).to.be.equal(3);
+                    expect(response.levels.length).to.be.equal(3);
+                    expect(response.levels[0].fullName).to.be.equal('grand');
+                    expect(response.levels[1].fullName).to.be.equal('grand.parent');
+                    expect(response.levels[2].fullName).to.be.equal('grand.parent.child');
+                    expect(response.parentNamespaceId().fullName).to.be.equal('grand.parent');
+                    expect(response.owner.publicKey).to.be.equal(publicAccount.publicKey);
+                    expect(response.startHeight.compact()).to.be.equal(666666);
+                    expect(response.endHeight.compact()).to.be.equal(999999);
+                    expect(response.alias.type).to.be.equal(AliasType.Address);
+                    expect((response.alias.address as any).plain()).to.be.equal(address.plain());
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getNamespacesFromAccounts', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Mosaic,
+                    // address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    mosaicId: [777777, 888888] // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespacesFromAccounts', () => Promise.resolve([dto]));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getNamespacesFromAccounts([address]).subscribe(responses => {
+                responses.forEach(response => {
+                    expect(responses.length).to.be.equal(1);
+                    expect(response.active).to.be.equal(true);
+                    expect(response.index).to.be.equal(666);
+                    expect(response.metaId).to.be.equal('some meta id');
+                    expect(response.isRoot()).to.be.equal(false);
+                    expect(response.depth).to.be.equal(3);
+                    expect(response.levels.length).to.be.equal(3);
+                    expect(response.levels[0].fullName).to.be.equal('grand');
+                    expect(response.levels[1].fullName).to.be.equal('grand.parent');
+                    expect(response.levels[2].fullName).to.be.equal('grand.parent.child');
+                    expect(response.parentNamespaceId().fullName).to.be.equal('grand.parent');
+                    expect(response.owner.publicKey).to.be.equal(publicAccount.publicKey);
+                    expect(response.startHeight.compact()).to.be.equal(666666);
+                    expect(response.endHeight.compact()).to.be.equal(999999);
+                    expect(response.alias.type).to.be.equal(AliasType.Mosaic);
+                    expect((response.alias.mosaicId as any).id.toDTO()[0]).to.be.equal(777777);
+                    expect((response.alias.mosaicId as any).id.toDTO()[1]).to.be.equal(888888);
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getNamespacesName', () => {
+        const dto = {
+            namespaceId: 'some.namespace',
+            name: 'some name'
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespacesNames', () => Promise.resolve([dto, dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getNamespacesName([new NamespaceId([333333, 444444])]).subscribe(responses => {
+                expect(responses.length).to.be.equal(2);
+                responses.forEach(response => {
+                    expect(response.name).to.be.equal('some name');
+                    expect(response.namespaceId.fullName).to.be.equal('some.namespace');
+                });
+                done();
+            })
+        });
+    });
+
+    describe('getLinkedMosaicId', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Mosaic,
+                    // address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    mosaicId: [777777, 888888] // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespace', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getLinkedMosaicId(new NamespaceId([333333, 444444])).subscribe(response => {
+                expect(response.toDTO().id[0]).to.be.equal(777777);
+                expect(response.toDTO().id[1]).to.be.equal(888888);
+                done();
+            })
+        });
+    });
+
+    describe('getLinkedMosaicId - throw', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Address,
+                    address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    // mosaicId: [777777, 888888] // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespace', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.getLinkedMosaicId(new NamespaceId([333333, 444444])).subscribe(_ => {
+                done('fail');
+            }, error => {
+                expect(error.message).to.be.equal('No mosaicId is linked to namespace \'grand\'');
+                done();
+            });
+        });
+    });
+
+    describe('getLinkedAddress', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Address,
+                    address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    // mosaicId: [777777, 888888] // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespace', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client - and throw', (done) => {
+            client.getLinkedAddress(new NamespaceId([333333, 444444])).subscribe(response => {
+                expect(response.plain()).to.be.equal(address.plain());
+                done();
+            });
+        });
+    });
+
+    describe('getLinkedAddress - throw', () => {
+        const dto = {
+            meta: {
+                active: true,
+                index: 666,
+                id: 'some meta id'
+            },
+            namespace: {
+                type: NamespaceType.SubNamespace,
+                depth: 3,
+                parentId: 'grand.parent',
+                owner: publicAccount.publicKey,
+                startHeight: UInt64.fromUint(666666).toDTO(),
+                endHeight: UInt64.fromUint(999999).toDTO(),
+                level0: 'grand',
+                level1: 'grand.parent',
+                level2: 'grand.parent.child',
+                alias: {
+                    type: AliasType.Mosaic,
+                    // address: Convert.uint8ToHex(RawAddress.stringToAddress(address.plain())), // either
+                    mosaicId: [777777, 888888] // or
+                }
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).namespaceRoutesApi, 'getNamespace', () => Promise.resolve(dto));
+            sandbox.on(client, 'getNetworkTypeObservable', () => of(NetworkType.MIJIN_TEST));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client - and throw', (done) => {
+            client.getLinkedAddress(new NamespaceId([333333, 444444])).subscribe(_ => {
+                done('fail');
+            }, error => {
+                expect(error.message).to.be.equal('No address is linked to namespace \'grand\'');
+                done();
+            })
+        });
+    });
+});

--- a/test/infrastructure/NetworkHttp.spec.ts
+++ b/test/infrastructure/NetworkHttp.spec.ts
@@ -1,0 +1,71 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { NetworkHttp } from '../../src/infrastructure/infrastructure';
+import { NetworkType, PublicAccount } from '../../src/model/model';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new NetworkHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('NetworkHttp', () => {
+
+    describe('getNetworkType - unsupported', () => {
+        const dto = {
+            name: 'unsupported'
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).networkRoutesApi, 'getNetworkType', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should call api client', (done) => {
+            client.getNetworkType().subscribe(
+                _ => done('failed'),
+                error => {
+                    expect(error.message).to.be.equal('network unsupported is not supported yet by the sdk');
+                    done();
+                });
+        });
+    })
+
+    describe('getNetworkType', () => {
+        let i = 0;
+        const nameValue = [
+            ['mijinTest', NetworkType.MIJIN_TEST],
+            ['mijin', NetworkType.MIJIN],
+            ['testnet', NetworkType.TEST_NET],
+            ['publicTest', NetworkType.TEST_NET],
+            ['privateTest', NetworkType.PRIVATE_TEST],
+            ['mainnet', NetworkType.MAIN_NET],
+            ['public', NetworkType.MAIN_NET],
+            ['private', NetworkType.PRIVATE]
+        ];
+        const getDto = (idx) => Promise.resolve({
+            name: nameValue[idx][0]
+        });
+        beforeEach(() => {
+            sandbox.on((client as any).networkRoutesApi, 'getNetworkType', () => Promise.resolve(getDto(i)));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        nameValue.forEach(value => {
+            it('should call api client', (done) => {
+                client.getNetworkType().subscribe(response => {
+                    expect(response).to.be.equal(value[1]);
+                    i += 1;
+                    done();
+                });
+            });
+        });
+    })
+});

--- a/test/infrastructure/NodeHttp.spec.ts
+++ b/test/infrastructure/NodeHttp.spec.ts
@@ -1,0 +1,67 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { NodeHttp } from '../../src/infrastructure/infrastructure';
+import { NetworkType, PublicAccount } from '../../src/model/model';
+import { deepEqual } from 'assert';
+
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new NodeHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+const networkType = NetworkType.MIJIN_TEST;
+const publicAccount = PublicAccount.createFromPublicKey('6'.repeat(64), networkType);
+const address = publicAccount.address;
+
+describe('NodeHttp', () => {
+
+    describe('getNodeInfo', () => {
+        const dto = {
+            publicKey: 'some public key',
+            port: 7890,
+            networkIdentifier: NetworkType.MIJIN_TEST,
+            version: 666,
+            roles: 3,
+            host: 'some host',
+            friendlyName: 'some friendly name',
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).nodeRoutesApi, 'getNodeInfo', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should call api client', (done) => {
+            client.getNodeInfo().subscribe(result => {
+                deepEqual(result, dto);
+                done();
+            });
+        });
+    })
+
+    describe('getNodeTime', () => {
+        const dto = {
+            communicationTimestamps: {
+                sendTimestamp: [666666, 999999],
+                receiveTimestamp: [777777, 888888]
+            }
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).nodeRoutesApi, 'getNodeTime', () => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('should call api client', (done) => {
+            client.getNodeTime().subscribe(result => {
+                deepEqual(result.sendTimeStamp, dto.communicationTimestamps.sendTimestamp);
+                deepEqual(result.receiveTimeStamp, dto.communicationTimestamps.receiveTimestamp);
+                done();
+            });
+        });
+    })
+
+});

--- a/test/infrastructure/TransactionHttp.spec.ts
+++ b/test/infrastructure/TransactionHttp.spec.ts
@@ -1,0 +1,150 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import { TransactionHttp } from '../../src/infrastructure/infrastructure';
+import { SignedTransaction, TransactionType, CosignatureSignedTransaction } from '../../src/model/model';
+import { deepEqual } from 'assert';
+import * as createFromDto from '../../src/infrastructure/transaction/CreateTransactionFromDTO';
+chai.use(spies);
+const expect = chai.expect;
+
+const client = new TransactionHttp('http://nonexistent:0');
+const sandbox = (chai as any).spy.sandbox();
+
+describe('TransactionHttp', () => {
+
+    describe('getTransaction', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'getTransaction', (tx) => Promise.resolve('api called'));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called': 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            const txId = 'some-txid';
+            client.getTransaction(txId).subscribe(response => {
+                expect(response).to.be.equal('deserialization called');
+                done();
+            })
+        });
+    });
+
+    describe('getTransactions', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'getTransactions', (tx) => Promise.resolve(['api called']));
+            sandbox.on(createFromDto, 'CreateTransactionFromDTO', (dto) => dto === 'api called' ? 'deserialization called': 'not ok');
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            const txId = 'some-txid';
+            client.getTransactions([txId]).subscribe(response => {
+                deepEqual(response, ['deserialization called']);
+                done();
+            })
+        });
+    });
+
+    describe('getTransactionStatus', () => {
+        const dto = {
+            status: 'some status',
+            group: 'some group',
+            hash: 'some hash',
+            deadline: undefined,
+            height: undefined
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'getTransactionStatus', (txId) => Promise.resolve(dto));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            const txId = 'some-txid';
+            client.getTransactionStatus(txId).subscribe(response => {
+                deepEqual(response, dto);
+                done();
+            })
+        });
+    });
+
+    describe('getTransactionsStatuses', () => {
+        const dto = {
+            status: 'some status',
+            group: 'some group',
+            hash: 'some hash',
+            deadline: undefined,
+            height: undefined
+        };
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'getTransactionsStatuses', (txId) => Promise.resolve([dto]));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            const txId = 'some-txid';
+            client.getTransactionsStatuses([txId]).subscribe(response => {
+                deepEqual(response, [dto]);
+                done();
+            })
+        });
+    });
+
+    describe('announce', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'announceTransaction', (tx) => Promise.resolve({message: 'some message'}));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.announce({} as SignedTransaction).subscribe(response => {
+                expect(response.message).to.be.equal('some message');
+                done();
+            })
+        });
+    });
+
+    describe('announceAggregateBonded', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'announcePartialTransaction', (tx) => {
+                return Promise.resolve({message: 'some message'});
+            });
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should throw if not aggregate bonded', (done) => {
+            client.announceAggregateBonded({ type: TransactionType.AGGREGATE_COMPLETE } as SignedTransaction).subscribe(
+                _ => done('failed'),
+                error => {
+                    expect(error).to.be.equal('Only Transaction Type 0x4241 is allowed for announce aggregate bonded');
+                    done();
+                });
+        });
+        it('should call api client', (done) => {
+            client.announceAggregateBonded({ type: TransactionType.AGGREGATE_BONDED } as SignedTransaction).subscribe(response => {
+                expect(response.message).to.be.equal('some message');
+                done();
+            })
+        });
+    });
+
+    describe('announceAggregateBondedCosignature', () => {
+        beforeEach(() => {
+            sandbox.on((client as any).transactionRoutesApi, 'announceCosignatureTransaction', (tx) => Promise.resolve({message: 'some message'}));
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('should call api client', (done) => {
+            client.announceAggregateBondedCosignature({} as CosignatureSignedTransaction).subscribe(response => {
+                expect(response.message).to.be.equal('some message');
+                done();
+            })
+        });
+    });
+
+});


### PR DESCRIPTION
- increase coverage by a) adding tests for infrastructure *Http and b) excluding generated code (infrastructure/api and infrastructure/buffers)
- report coverage using only single node version to avoid the race and confusion
- minor fixes
- release will be built using node 12, which is now newest LTS